### PR TITLE
Add support for webkit

### DIFF
--- a/shot_scraper/cli.py
+++ b/shot_scraper/cli.py
@@ -13,7 +13,7 @@ import yaml
 
 from shot_scraper.utils import filename_for_url, url_or_file_path
 
-BROWSERS = ("chromium", "firefox", "chrome", "chrome-beta")
+BROWSERS = ("chromium", "firefox", "webkit", "chrome", "chrome-beta")
 
 
 def browser_option(fn):

--- a/shot_scraper/cli.py
+++ b/shot_scraper/cli.py
@@ -211,6 +211,8 @@ def _browser_context(
         browser_obj = p.chromium.launch(**browser_kwargs)
     elif browser == "firefox":
         browser_obj = p.firefox.launch(**browser_kwargs)
+    elif browser == "webkit":
+        browser_obj = p.webkit.launch(**browser_kwargs)
     else:
         browser_kwargs["channel"] = browser
         browser_obj = p.chromium.launch(**browser_kwargs)

--- a/tests/run_examples.sh
+++ b/tests/run_examples.sh
@@ -68,6 +68,8 @@ shot-scraper 'https://www.whatismybrowser.com/detect/what-is-my-user-agent/' \
   -o /tmp/whatismybrowser-default-chromium.png -h 400 -w 800
 shot-scraper 'https://www.whatismybrowser.com/detect/what-is-my-user-agent/' \
   -o /tmp/whatismybrowser-firefox.png -h 400 -w 800 -b firefox
+shot-scraper 'https://www.whatismybrowser.com/detect/what-is-my-user-agent/' \
+  -o /tmp/whatismybrowser-webkit.png -h 400 -w 800 -b webkit
 # And using multi
 echo '# empty file' > empty.yml
 shot-scraper multi empty.yml


### PR DESCRIPTION
Not sure why `webkit` was excluded seeing as it's one of the three major browsers supported by Playwright, but this PR adds it.