### PR TITLE
Use "jpg" as ext when quality is specified

### DIFF
--- a/shot_scraper/cli.py
+++ b/shot_scraper/cli.py
@@ -146,7 +146,8 @@ def shot(
         shot-scraper https://simonwillison.net -s '#bighead'
     """
     if output is None:
-        output = filename_for_url(url, file_exists=os.path.exists)
+        ext = "jpg" if quality else None
+        output = filename_for_url(url, ext, file_exists=os.path.exists)
     shot = {
         "url": url,
         "selectors": selectors,

--- a/shot_scraper/cli.py
+++ b/shot_scraper/cli.py
@@ -147,7 +147,7 @@ def shot(
     """
     if output is None:
         ext = "jpg" if quality else None
-        output = filename_for_url(url, ext, file_exists=os.path.exists)
+        output = filename_for_url(url, ext=ext, file_exists=os.path.exists)
     shot = {
         "url": url,
         "selectors": selectors,


### PR DESCRIPTION
Default to using "jpg" as the file extension if quality is specified. 

Currently if no output is specified the image will be saved as a jpeg but named as with a png extension.