### PR TITLE
fix 'helpful' en-dashing in headings

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -8,7 +8,7 @@ Use `-o filename.json` to write the output to a file instead of displaying it.
 
 Add `--javascript SCRIPT` to execute custom JavaScript before taking the snapshot.
 
-## shot-scraper accessibility --help
+## shot-scraper accessibility \-\-help
 
 Full `--help` for this command:
 

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -8,7 +8,7 @@ Use `-o filename.json` to write the output to a file instead of displaying it.
 
 Add `--javascript SCRIPT` to execute custom JavaScript before taking the snapshot.
 
-## shot-scraper accessibility \-\-help
+## `shot-scraper accessibility --help`
 
 Full `--help` for this command:
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -19,7 +19,7 @@ To take authenticated screenshots you can then use the `-a` or `--auth` options 
     shot-scraper https://datasette-auth-passwords-demo.datasette.io/ \
       -a auth.json -o authed.png
 
-## shot-scraper auth \-\-help
+## `shot-scraper auth --help`
 
 Full `--help` for `shot-scraper auth`:
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -19,7 +19,7 @@ To take authenticated screenshots you can then use the `-a` or `--auth` options 
     shot-scraper https://datasette-auth-passwords-demo.datasette.io/ \
       -a auth.json -o authed.png
 
-## shot-scraper auth --help
+## shot-scraper auth \-\-help
 
 Full `--help` for `shot-scraper auth`:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,7 +19,7 @@ If you want to use other browsers such as Firefox you should install those too:
 % shot-scraper install -b firefox
 ```
 
-## shot-scraper shot \-\-help
+## `shot-scraper shot --help`
 
 Full `--help` for the `shot-scraper install` command:
 <!-- [[[cog

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,7 +19,7 @@ If you want to use other browsers such as Firefox you should install those too:
 % shot-scraper install -b firefox
 ```
 
-## shot-scraper shot --help
+## shot-scraper shot \-\-help
 
 Full `--help` for the `shot-scraper install` command:
 <!-- [[[cog

--- a/docs/multi.md
+++ b/docs/multi.md
@@ -98,7 +98,7 @@ You can include desired `height`, `width`, `quality`, `wait` and `wait_for` opti
   wait_for: document.querySelector('#bighead')
 ```
 
-## shot-scraper multi \-\-help
+## `shot-scraper multi --help`
 
 Full `--help` for this command:
 

--- a/docs/multi.md
+++ b/docs/multi.md
@@ -98,7 +98,7 @@ You can include desired `height`, `width`, `quality`, `wait` and `wait_for` opti
   wait_for: document.querySelector('#bighead')
 ```
 
-## shot-scraper multi --help
+## shot-scraper multi \-\-help
 
 Full `--help` for this command:
 

--- a/docs/pdf.md
+++ b/docs/pdf.md
@@ -9,7 +9,7 @@ This will save to `datasette-io.pdf`. You can use `-o` to specify a filename:
     shot-scraper pdf https://datasette.io/tutorials/learn-sql \
       -o learn-sql.pdf
 
-## shot-scraper pdf \-\-help
+## `shot-scraper pdf --help`
 
 Full `--help` for this command:
 

--- a/docs/pdf.md
+++ b/docs/pdf.md
@@ -9,7 +9,7 @@ This will save to `datasette-io.pdf`. You can use `-o` to specify a filename:
     shot-scraper pdf https://datasette.io/tutorials/learn-sql \
       -o learn-sql.pdf
 
-## shot-scraper pdf --help
+## shot-scraper pdf \-\-help
 
 Full `--help` for this command:
 

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -176,7 +176,7 @@ new Promise(takeShot => {
 ```
 If your custom code defines a `Promise`, `shot-scraper` will wait for that promise to complete before taking the screenshot. Here the screenshot does not occur until the `takeShot()` function is called.
 
-## shot-scraper shot \-\-help
+## ``shot-scraper shot --help`
 
 Full `--help` for this command:
 

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -176,7 +176,7 @@ new Promise(takeShot => {
 ```
 If your custom code defines a `Promise`, `shot-scraper` will wait for that promise to complete before taking the screenshot. Here the screenshot does not occur until the `takeShot()` function is called.
 
-## shot-scraper shot --help
+## shot-scraper shot \-\-help
 
 Full `--help` for this command:
 


### PR DESCRIPTION
The headings get double-hyphens turned into en-dashes:

<img width="435" alt="image" src="https://user-images.githubusercontent.com/23789/181355764-61c1cdc2-4047-4b43-80fa-c9e3ccad87ff.png">

I'm not sure if this fixes it (I haven't used .md in Sphinx before), but it might?