### PR TITLE
Reverse help arguments so Click recommends --help instead of -h

### DIFF
--- a/shot_scraper/cli.py
+++ b/shot_scraper/cli.py
@@ -45,7 +45,7 @@ def reduced_motion_option(fn):
     cls=DefaultGroup,
     default="shot",
     default_if_no_args=True,
-    context_settings=dict(help_option_names=["-h", "--help"]),
+    context_settings=dict(help_option_names=["--help", "-h"]),
 )
 @click.version_option()
 def cli():


### PR DESCRIPTION
Change to make Click recommend `--help` instead of `-h` to avoid conflict with `-h` (`--height`) parameter.

I would probably remove `-h` entirely, but not sure how important maintaining that is.

----

This is trivial, but tripped me up.

**Before this PR:**
```
$ shot-scraper
Usage: shot-scraper shot [OPTIONS] URL
Try 'shot-scraper shot -h' for help.
[...]
$ shot-scraper shot
Usage: shot-scraper shot [OPTIONS] URL
Try 'shot-scraper shot -h' for help.
[...]
```

The recommendation is to run `shot-scraper shot -h` for help about the tool, but `-h` is actually the shortcut for "height":

```
$ shot-scraper shot -h
Error: Option '-h' requires an argument.
$ shot-scraper shot --help | grep -- -h
  -h, --height INTEGER   Height of browser window and shot - defaults to the
```

**After this PR:**

```
.env/bin/shot-scraper
Usage: shot-scraper shot [OPTIONS] URL
Try 'shot-scraper shot --help' for help.
[...]
$.env/bin/shot-scraper shot
Usage: shot-scraper shot [OPTIONS] URL
Try 'shot-scraper shot --help' for help.
[...]
```

<!-- readthedocs-preview shot-scraper start -->
----
:books: Documentation preview :books:: https://shot-scraper--84.org.readthedocs.build/en/84/

<!-- readthedocs-preview shot-scraper end -->