### PR TITLE
Mention playwright install requirement for tests in contributing.md

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -10,6 +10,10 @@ Or if you are using `pipenv`:
 
     pipenv shell
 
+Playwright must be installed for the tests to run:
+
+    playwright install
+
 Now install the dependencies and test dependencies:
 
     pip install -e '.[test]'


### PR DESCRIPTION
Add mention of needing to run `playwright install` if contributing/testing changes.

The `pytest` tests don't clearly state why they fail if playwright isn't installed. 

`tests/run_examples.sh` does mention it, in the ouput, but I'd expect people to run `pytest` first.

<!-- readthedocs-preview shot-scraper start -->
----
:books: Documentation preview :books:: https://shot-scraper--85.org.readthedocs.build/en/85/

<!-- readthedocs-preview shot-scraper end -->