### PR TITLE
Use Read the Docs action v1

### DIFF
--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -11,6 +11,6 @@ jobs:
   documentation-links:
     runs-on: ubuntu-latest
     steps:
-      - uses: readthedocs/readthedocs-preview@main
+      - uses: readthedocs/actions/preview@v1
         with:
           project-slug: "shot-scraper"


### PR DESCRIPTION
Read the Docs repository was renamed from `readthedocs/readthedocs-preview` to `readthedocs/actions/`. Now, the `preview` action is under `readthedocs/actions/preview` and is tagged as `v1`

<!-- readthedocs-preview shot-scraper start -->
----
:books: Documentation preview :books:: https://shot-scraper--86.org.readthedocs.build/en/86/

<!-- readthedocs-preview shot-scraper end -->