### PR TITLE
Add additional pdf formatting options

### DIFF
--- a/docs/pdf.md
+++ b/docs/pdf.md
@@ -46,13 +46,19 @@ Usage: shot-scraper pdf [OPTIONS] URL
       shot-scraper pdf invoice.html -o invoice.pdf
 
 Options:
-  -a, --auth FILENAME    Path to JSON authentication context file
+  -a, --auth FILENAME             Path to JSON authentication context file
   -o, --output FILE
-  -j, --javascript TEXT  Execute this JS prior to creating the PDF
-  --wait INTEGER         Wait this many milliseconds before taking the
-                         screenshot
-  --media-screen         Use screen rather than print styles
-  --landscape            Use landscape orientation
-  -h, --help             Show this message and exit.
+  -j, --javascript TEXT           Execute this JS prior to creating the PDF
+  --wait INTEGER                  Wait this many milliseconds before taking the
+                                  screenshot
+  --media-screen                  Use screen rather than print styles
+  --landscape                     Use landscape orientation
+  --format [Letter|Legal|Tabloid|Ledger|A0|A1|A2|A3|A4|A5|A6]
+                                  Which standard paper size to use
+  --width TEXT                    PDF width including units, e.g. 10cm
+  --height TEXT                   PDF height including units, e.g. 10cm
+  --scale FLOAT RANGE             Scale of the webpage rendering  [0.1<=x<=2.0]
+  --print-background              Print background graphics
+  -h, --help                      Show this message and exit.
 ```
 <!-- [[[end]]] -->

--- a/shot_scraper/cli.py
+++ b/shot_scraper/cli.py
@@ -500,7 +500,37 @@ def javascript(
     "--media-screen", is_flag=True, help="Use screen rather than print styles"
 )
 @click.option("--landscape", is_flag=True, help="Use landscape orientation")
-def pdf(url, auth, output, javascript, wait, media_screen, landscape):
+@click.option(
+    "--format",
+    "format_",
+    type=click.Choice(
+        ["Letter", "Legal", "Tabloid", "Ledger", "A0", "A1", "A2", "A3", "A4", "A5", "A6"],
+        case_sensitive=False,
+    ),
+    help="Which standard paper size to use",
+)
+@click.option("--width", help="PDF width including units, e.g. 10cm")
+@click.option("--height", help="PDF height including units, e.g. 10cm")
+@click.option(
+    "--scale",
+    type=click.FloatRange(min=0.1, max=2.0),
+    help="Scale of the webpage rendering",
+)
+@click.option("--print-background", is_flag=True, help="Print background graphics")
+def pdf(
+    url,
+    auth,
+    output,
+    javascript,
+    wait,
+    media_screen,
+    landscape,
+    format_,
+    width,
+    height,
+    scale,
+    print_background,
+):
     """
     Create a PDF of the specified page
 
@@ -530,6 +560,11 @@ def pdf(url, auth, output, javascript, wait, media_screen, landscape):
 
         kwargs = {
             "landscape": landscape,
+            "format": format_,
+            "width": width,
+            "height": height,
+            "scale": scale,
+            "print_background": print_background,
         }
         if output != "-":
             kwargs["path"] = output


### PR DESCRIPTION
Implements new PDF options as requested in #26:

- `--format`
- `--print-background`
- `--scale`
- `--width`
- `--height`

New option arguments are validated with Click and passed to Playwright. 

Documentation is updated with Cog.

<!-- readthedocs-preview shot-scraper start -->
----
:books: Documentation preview :books:: https://shot-scraper--87.org.readthedocs.build/en/87/

<!-- readthedocs-preview shot-scraper end -->