### PR TITLE
add more ways to configure web browser from command-line

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -48,6 +48,9 @@ Options:
   -b, --browser [chromium|firefox|webkit|chrome|chrome-beta]
                                   Which browser to use
   --user-agent TEXT               User-Agent header to use
+  --system-browser                Use web browser installed by the system
+  --browser-args TEXT             Browser command-line arguments
+  --ignore-https-errors           Ignore HTTPS errors
   --devtools                      Open browser DevTools
   --help                          Show this message and exit.
 ```

--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -164,6 +164,9 @@ Options:
                                   Which browser to use
   --user-agent TEXT               User-Agent header to use
   --reduced-motion                Emulate 'prefers-reduced-motion' media feature
+  --system-browser                Use web browser installed by the system
+  --browser-args TEXT             Browser command-line arguments
+  --ignore-https-errors           Ignore HTTPS errors
   --help                          Show this message and exit.
 ```
 <!-- [[[end]]] -->

--- a/docs/multi.md
+++ b/docs/multi.md
@@ -143,6 +143,9 @@ Options:
                                   Which browser to use
   --user-agent TEXT               User-Agent header to use
   --reduced-motion                Emulate 'prefers-reduced-motion' media feature
+  --system-browser                Use web browser installed by the system
+  --browser-args TEXT             Browser command-line arguments
+  --ignore-https-errors           Ignore HTTPS errors
   --help                          Show this message and exit.
 ```
 <!-- [[[end]]] -->

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -268,6 +268,9 @@ Options:
                                   Which browser to use
   --user-agent TEXT               User-Agent header to use
   --reduced-motion                Emulate 'prefers-reduced-motion' media feature
+  --system-browser                Use web browser installed by the system
+  --browser-args TEXT             Browser command-line arguments
+  --ignore-https-errors           Ignore HTTPS errors
   --help                          Show this message and exit.
 ```
 <!-- [[[end]]] -->

--- a/shot_scraper/cli.py
+++ b/shot_scraper/cli.py
@@ -10,7 +10,7 @@ import sys
 import textwrap
 import time
 import yaml
-from distutils import spawn
+from shutil import which
 
 from shot_scraper.utils import filename_for_url, url_or_file_path
 
@@ -302,7 +302,7 @@ def _browser_context(
 ):
     browser_kwargs = dict(headless=not interactive, devtools=devtools)
     if system_browser:
-        browser_kwargs['executable_path'] = spawn.find_executable(browser)
+        browser_kwargs['executable_path'] = which(browser)
     if browser_args:
         browser_kwargs["args"] = browser_args.split(' ')
     if browser == "chromium":


### PR DESCRIPTION
* option to use system browser
* option to add custom browser command-line arguments
* option to ignore https headers

<!-- readthedocs-preview shot-scraper start -->
----
:books: Documentation preview :books:: https://shot-scraper--91.org.readthedocs.build/en/91/

<!-- readthedocs-preview shot-scraper end -->