### PR TITLE
Fix for Windows

### DIFF
--- a/shot_scraper/cli.py
+++ b/shot_scraper/cli.py
@@ -873,10 +873,14 @@ def auth(url, context_file, browser, user_agent, devtools, log_console):
 
 
 def _check_and_absolutize(filepath):
-    path = pathlib.Path(filepath)
-    if path.exists():
-        return path.absolute()
-    return False
+    try:
+        path = pathlib.Path(filepath)
+        if path.exists():
+            return path.absolute()
+        return False
+    except OSError:
+        # On Windows, instantiating a Path object on `http://` or `https://` will raise an exception
+        return False
 
 
 def take_shot(


### PR DESCRIPTION
This fix makes `shot-scraper https://swimm.io` work on Windows.

See https://github.com/python/cpython/issues/87021

<!-- readthedocs-preview shot-scraper start -->
----
:books: Documentation preview :books:: https://shot-scraper--104.org.readthedocs.build/en/104/

<!-- readthedocs-preview shot-scraper end -->