### PR TITLE
Updating the Shot-Scraper docs with GitBook!

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,6 @@
-# shot-scraper
+# Welcome
+
+## `Shot-Scraper`
 
 A command-line utility for taking automated screenshots of websites
 
@@ -9,9 +11,10 @@ pip install shot-scraper
 shot-scraper install
 shot-scraper https://github.com/simonw/shot-scraper -h 900
 ```
+
 Produces this screenshot in a file called `github-com-simonw-shot-scraper.png`:
 
-<img src="https://raw.githubusercontent.com/simonw/shot-scraper-screenshot/main/shot.png" alt="A screenshot of the shot-scraper page on GitHub">
+![A screenshot of the shot-scraper page on GitHub](https://raw.githubusercontent.com/simonw/shot-scraper-screenshot/main/shot.png)
 
 **Contents**
 
@@ -30,5 +33,6 @@ accessibility
 github-actions
 contributing
 ```
-```{include} ../README.md
+
+```{include}
 ```

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,13 @@
+# Table of contents
+
+* [Welcome](README.md)
+* [Installation](installation.md)
+* [Taking a screenshot](screenshots.md)
+* [Websites that need authentication](authentication.md)
+* [Taking multiple screenshots](multi.md)
+* [Scraping pages using JavaScript](javascript.md)
+* [Saving a web page to PDF](pdf.md)
+* [Dumping the HTML of a page](html.md)
+* [Dumping out an accessibility tree](accessibility.md)
+* [Using shot-scraper with GitHub Actions](github-actions.md)
+* [Contributing](contributing.md)

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -1,62 +1,76 @@
-(screenshots)=
-
 # Taking a screenshot
 
 To take a screenshot of a web page and write it to `datasette-io.png` run this:
 
-    shot-scraper https://datasette.io/
+```
+shot-scraper https://datasette.io/
+```
 
 If a file called `datasette-io.png` already exists the filename `datasette-io.1.png` will be used instead.
 
 You can use the `-o` option to specify a filename:
 
-    shot-scraper https://datasette.io/ -o datasette.png
+```
+shot-scraper https://datasette.io/ -o datasette.png
+```
 
 Use `-o -` to write the PNG image to standard output:
 
-    shot-scraper https://datasette.io/ -o - > datasette.png
+```
+shot-scraper https://datasette.io/ -o - > datasette.png
+```
 
 If you omit the protocol `http://` will be added automatically, and any redirects will be followed:
 
-    shot-scraper datasette.io -o datasette.png
+```
+shot-scraper datasette.io -o datasette.png
+```
 
-## Adjusting the browser width and height
+### Adjusting the browser width and height
 
 The browser window used to take the screenshots defaults to 1280px wide and 780px tall.
 
 You can adjust these with the `--width` and `--height` options (`-w` and `-h` for short):
 
-    shot-scraper https://datasette.io/ -o small.png --width 400 --height 800
+```
+shot-scraper https://datasette.io/ -o small.png --width 400 --height 800
+```
 
 If you provide both options, the resulting screenshot will be of that size. If you omit `--height` a full page length screenshot will be produced (the default).
 
-## Screenshotting a specific area with CSS selectors
+### Screenshotting a specific area with CSS selectors
 
 To take a screenshot of a specific element on the page, use `--selector` or `-s` with its CSS selector:
 
-    shot-scraper https://simonwillison.net/ -s '#bighead'
+```
+shot-scraper https://simonwillison.net/ -s '#bighead'
+```
 
 This produces `simonwillison-net.png` containing this image:
 
-<img src="https://raw.githubusercontent.com/simonw/shot-scraper-screenshot/main/shot-selector.png" alt="Just the header section from my blog">
+![Just the header section from my blog](https://raw.githubusercontent.com/simonw/shot-scraper-screenshot/main/shot-selector.png)
 
 When using `--selector` the height and width, if provided, will set the size of the browser window when the page is loaded but the resulting screenshot will still be the same dimensions as the element on the page.
 
 You can pass `--selector` multiple times. The resulting screenshot will cover the smallest area of the page that contains all of the elements you specified, for example:
 
-    shot-scraper https://simonwillison.net/ \
-      -s '#bighead' -s .overband \
-      -o bighead-multi-selector.png
+```
+shot-scraper https://simonwillison.net/ \
+  -s '#bighead' -s .overband \
+  -o bighead-multi-selector.png
+```
 
 To capture a rectangle around every element that matches a CSS selector, use `--selector-all`:
 
-    shot-scraper https://simonwillison.net/ \
-      --selector-all '.day' \
-      -o just-the-day-boxes.png
+```
+shot-scraper https://simonwillison.net/ \
+  --selector-all '.day' \
+  -o just-the-day-boxes.png
+```
 
 You can add `--padding 20` to add 20px of padding around the elements when the shot is taken.
 
-## Specifying elements using JavaScript filters
+### Specifying elements using JavaScript filters
 
 The `--js-selector` and `--js-selector-all` options can be used to use JavaScript expressions to select elements that cannot be targetted just using CSS selectors.
 
@@ -64,78 +78,96 @@ The options should be passed JavaScript expression that operates on the `el` var
 
 To take a screenshot of the first paragraph on the page that contains the text "shot-scraper" you could run the following:
 
-    shot-scraper https://github.com/simonw/shot-scraper \
-      --js-selector 'el.tagName == "P" && el.innerText.includes("shot-scraper")'
+```
+shot-scraper https://github.com/simonw/shot-scraper \
+  --js-selector 'el.tagName == "P" && el.innerText.includes("shot-scraper")'
+```
 
 The `el.tagName == "P"` part is needed here because otherwise the `<html>` element on the page will be the first to match the expression.
 
 The generated JavaScript that will be executed on the page looks like this:
+
 ```javascript
 Array.from(document.getElementsByTagName('*')).find(
   el => el.tagName == "P" && el.innerText.includes("shot-scraper")
 ).classList.add("js-selector-a1f5ba0fc4a4317e58a3bd11a0f16b96");
 ```
+
 The `--js-selector-all` option will select all matching elements, in a similar fashion to the `--selector-all` option described above.
 
-## Waiting for a delay
+### Waiting for a delay
 
 Sometimes a page will not have completely loaded before a screenshot is taken. You can use `--wait X` to wait the specified number of milliseconds after the page load event has fired before taking the screenshot:
 
-    shot-scraper https://simonwillison.net/ --wait 2000
+```
+shot-scraper https://simonwillison.net/ --wait 2000
+```
 
-## Waiting until a specific condition
+### Waiting until a specific condition
 
 In addition to waiting a specific amount of time, you can also wait until a JavaScript expression returns true using the `--wait-for expression` option.
 
 This example takes the screenshot the moment a `<div>` with an ID of `content` becomes available in the DOM:
 
-    shot-scraper https://.../ \
-      --wait-for 'document.querySelector("div#content")'
+```
+shot-scraper https://.../ \
+  --wait-for 'document.querySelector("div#content")'
+```
 
-## Executing custom JavaScript
+### Executing custom JavaScript
 
 You can use custom JavaScript to modify the page after it has loaded (after the 'onload' event has fired) but before the screenshot is taken using the `--javascript` option:
 
-    shot-scraper https://simonwillison.net/ \
-      -o simonwillison-pink.png \
-      --javascript "document.body.style.backgroundColor = 'pink';"
+```
+shot-scraper https://simonwillison.net/ \
+  -o simonwillison-pink.png \
+  --javascript "document.body.style.backgroundColor = 'pink';"
+```
 
-## Using JPEGs instead of PNGs
+### Using JPEGs instead of PNGs
 
 Screenshots default to PNG. You can save as a JPEG by specifying a `-o` filename that ends with `.jpg`.
 
 You can also use `--quality X` to save as a JPEG with the specified quality, in order to reduce the filesize. 80 is a good value to use here:
 
-    shot-scraper https://simonwillison.net/ \
-      -h 800 -o simonwillison.jpg --quality 80
-    % ls -lah simonwillison.jpg
-    -rw-r--r--@ 1 simon  staff   168K Mar  9 13:53 simonwillison.jpg
+```
+shot-scraper https://simonwillison.net/ \
+  -h 800 -o simonwillison.jpg --quality 80
+% ls -lah simonwillison.jpg
+-rw-r--r--@ 1 simon  staff   168K Mar  9 13:53 simonwillison.jpg
+```
 
-## Retina images
+### Retina images
 
-The `--retina` option sets a device scale factor of 2. This means that an image will have its resolution effectively doubled, emulating the display of images on [retina](https://en.wikipedia.org/wiki/Retina_display) or higher pixel density screens.
+The `--retina` option sets a device scale factor of 2. This means that an image will have its resolution effectively doubled, emulating the display of images on [retina](https://en.wikipedia.org/wiki/Retina\_display) or higher pixel density screens.
 
-    shot-scraper https://simonwillison.net/ -o simon.png \
-      --width 400 --height 600 --retina
+```
+shot-scraper https://simonwillison.net/ -o simon.png \
+  --width 400 --height 600 --retina
+```
 
 This example will produce an image that is 800px wide and 1200px high.
 
-## Interacting with the page
+### Interacting with the page
 
 Sometimes it's useful to be able to manually interact with a page before the screenshot is captured.
 
 Add the `--interactive` option to open a browser window that you can interact with. Then hit `<enter>` in the terminal when you are ready to take the shot and close the window.
 
-    shot-scraper https://simonwillison.net/ -o after-interaction.png \
-      --height 800 --interactive
+```
+shot-scraper https://simonwillison.net/ -o after-interaction.png \
+  --height 800 --interactive
+```
 
 This will output:
 
-    Hit <enter> to take the shot and close the browser window:
-      # And after you hit <enter>...
-    Screenshot of 'https://simonwillison.net/' written to 'after-interaction.png'
+```
+Hit <enter> to take the shot and close the browser window:
+  # And after you hit <enter>...
+Screenshot of 'https://simonwillison.net/' written to 'after-interaction.png'
+```
 
-## Logging all requests
+### Logging all requests
 
 It can sometimes be useful to see a list of all of the requests that the browser made while it was rendering a page.
 
@@ -144,6 +176,7 @@ Use `--log-requests` to output newline-delimited JSON representing each request,
 Pass `-` to output the list to standard output, or use a filename to write to a file on disk.
 
 The output looks like this:
+
 ```
 % shot-scraper http://datasette.io/ --log-requests -
 {"method": "GET", "url": "http://datasette.io/", "status": 302, "size": null, "timing": {"startTime": 1663211674984.7068, "domainLookupStart": 0.698, "domainLookupEnd": 1.897, "connectStart": 1.897, "secureConnectionStart": -1, "connectEnd": 18.726, "requestStart": 18.86, "responseStart": 99.75, "responseEnd": 101.75000000162981}}
@@ -151,17 +184,20 @@ The output looks like this:
 {"method": "GET", "url": "https://datasette.io/static/site.css", "status": 200, "size": 3952, "timing": {"startTime": 1663211675486.027, "domainLookupStart": -1, "domainLookupEnd": -1, "connectStart": -1, "secureConnectionStart": -1, "connectEnd": -1, "requestStart": 0.408, "responseStart": 99.407, "responseEnd": 100.433}}
 ...
 ```
+
 Note that the `size` field here will be the size of the response in bytes, but in some circumstances this will not be available and it will be returned as `"size": null`.
 
-## Taking screenshots of local HTML files
+### Taking screenshots of local HTML files
 
 You can pass the path to an HTML file on disk to take a screenshot of that rendered file:
 
-    shot-scraper index.html -o index.png
+```
+shot-scraper index.html -o index.png
+```
 
 CSS and images referenced from that file using relative paths will also be included.
 
-## Tips for executing JavaScript
+### Tips for executing JavaScript
 
 If you are using the `--javascript` option to execute code, that code will be executed after the page load event has fired but before the screenshot is taken.
 
@@ -169,9 +205,11 @@ You can use that code to do things like hide or remove specific page elements, c
 
 This code hides any element with a `[data-ad-rendered]` attribute and the element with `id="ensNotifyBanner"`:
 
-    document.querySelectorAll(
-        '[data-ad-rendered],#ensNotifyBanner'
-    ).forEach(el => el.style.display = 'none')
+```
+document.querySelectorAll(
+    '[data-ad-rendered],#ensNotifyBanner'
+).forEach(el => el.style.display = 'none')
+```
 
 You can execute that like so:
 
@@ -186,6 +224,7 @@ document.querySelectorAll(
 In some cases you may need to add a pause that executes during your custom JavaScript before the screenshot is taken - for example if you click on a button that triggers a short fading animation.
 
 You can do that using the following pattern:
+
 ```javascript
 new Promise(takeShot => {
   // Your code goes here
@@ -196,9 +235,10 @@ new Promise(takeShot => {
   }, 1000);
 });
 ```
+
 If your custom code defines a `Promise`, `shot-scraper` will wait for that promise to complete before taking the screenshot. Here the screenshot does not occur until the `takeShot()` function is called.
 
-## Viewing console.log() output
+### Viewing console.log() output
 
 Almost all of the `shot-scraper` commands accept a `--log-console` option, which will cause them to output any calls to `console.log()` to standard error while the command is running.
 
@@ -226,21 +266,10 @@ See https://www.facebook.com/selfxss for more information.
 Screenshot of 'http://facebook.com' written to 'facebook-com.png'
 ```
 
-## `shot-scraper shot --help`
+### `shot-scraper shot --help`
 
 Full `--help` for this command:
 
-<!-- [[[cog
-import cog
-from shot_scraper import cli
-from click.testing import CliRunner
-runner = CliRunner()
-result = runner.invoke(cli.cli, ["shot", "--help"])
-help = result.output.replace("Usage: cli", "Usage: shot-scraper")
-cog.out(
-    "```\n{}\n```\n".format(help.strip())
-)
-]]] -->
 ```
 Usage: shot-scraper shot [OPTIONS] URL
 
@@ -306,4 +335,3 @@ Options:
   --skip                          Skip pages that return HTTP errors
   --help                          Show this message and exit.
 ```
-<!-- [[[end]]] -->


### PR DESCRIPTION
Hello @simonw! 

Addison here from [GitBook](https://gitbook.com/). I came across this repo for your product docs, and wanted to share with you some of the things we're working on at GitBook to make documentation more accessible and engaging.

I went ahead and used our [GitHub sync](https://docs.gitbook.com/getting-started/git-sync) feature to get your site back up and running at https://open-source.gitbook.io/shot-scraper/

It only took me 5min to get it live 🤯

At GitBook, we've been working on building the best tool for technical teams to document their work - and we've seen a lot of community docs move to GitBook recently as well for a few reasons:

- Free hosting
- Custom branding / theming
- Custom URLs & Domains
- GitHub/GitLab sync (this is what made getting the docs up and running so fast!)
- Integrated Search (with AI features on the way)
- Deploy Previews for PRs
- Continuous deployment

I'd love to give you a full product tour if you're interested? We're building out a content library of technical guides & communities built on GitBook, and think it would be great to have you and these docs in on the launch.

Feel free to let me know here, or shoot me a message to addison (@) gitbook.com!

Addison

<!-- readthedocs-preview shot-scraper start -->
----
:books: Documentation preview :books:: https://shot-scraper--106.org.readthedocs.build/en/106/

<!-- readthedocs-preview shot-scraper end -->