### PR TITLE
Add option to bypass Content-Security-Policy when executing Javascript

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -40,6 +40,7 @@ Options:
   --log-console          Write console.log() to stderr
   --fail                 Fail with an error code if a page returns an HTTP error
   --skip                 Skip pages that return HTTP errors
+  --bypass-csp           Bypass Content-Security-Policy
   --help                 Show this message and exit.
 ```
 <!-- [[[end]]] -->

--- a/docs/html.md
+++ b/docs/html.md
@@ -68,6 +68,7 @@ Options:
   --fail                          Fail with an error code if a page returns an
                                   HTTP error
   --skip                          Skip pages that return HTTP errors
+  --bypass-csp                    Bypass Content-Security-Policy
   --silent                        Do not output any messages
   --help                          Show this message and exit.
 ```

--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -185,6 +185,7 @@ Options:
   --fail                          Fail with an error code if a page returns an
                                   HTTP error
   --skip                          Skip pages that return HTTP errors
+  --bypass-csp                    Bypass Content-Security-Policy
   --help                          Show this message and exit.
 ```
 <!-- [[[end]]] -->

--- a/docs/pdf.md
+++ b/docs/pdf.md
@@ -63,6 +63,7 @@ Options:
   --fail                          Fail with an error code if a page returns an
                                   HTTP error
   --skip                          Skip pages that return HTTP errors
+  --bypass-csp                    Bypass Content-Security-Policy
   --silent                        Do not output any messages
   --help                          Show this message and exit.
 ```

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -315,6 +315,7 @@ Options:
   --fail                          Fail with an error code if a page returns an
                                   HTTP error
   --skip                          Skip pages that return HTTP errors
+  --bypass-csp                    Bypass Content-Security-Policy
   --silent                        Do not output any messages
   --help                          Show this message and exit.
 ```

--- a/tests/run_examples.sh
+++ b/tests/run_examples.sh
@@ -152,3 +152,5 @@ shot-scraper multi empty.yml
   wait_for: |-
     document.querySelector("div")
 ' | shot-scraper multi - --fail)
+# --bypass-csp
+shot-scraper javascript github.com "async () => { await import('https://cdn.jsdelivr.net/npm/left-pad/+esm'); return 'content-security-policy ignored' }" -o examples/github-csp.json --bypass-csp


### PR DESCRIPTION
Refs: #114

Adds a `--bypass-csp` option to the commands that allow Javascript to be executed.

The additional test case that has been added loads Github and attempts to load an external module. With the `--bypass-csp` flag this will work. You can execute the following on the current version of `shot-scraper` to see it failing:

```
shot-scraper javascript github.com "async () => { await import('https://cdn.jsdelivr.net/npm/left-pad/+esm'); return 'content-security-policy ignored' }"
```

The above will continue to fail with this change until `--bypass-csp` is added.

I have added the flag to the documentation by have not added a new documentation block to the Javascript page for this yet. I'm happy to write up an example if you're keen to accept this PR.

I'm also interested in feedback in how the help text should be phrased. I went with the simplest possible phrasing but it does assume that the user knows what a CSP is.

<!-- readthedocs-preview shot-scraper start -->
----
:books: Documentation preview :books:: https://shot-scraper--116.org.readthedocs.build/en/116/

<!-- readthedocs-preview shot-scraper end -->