### PR TITLE
Improve documentation a11y

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,17 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/conf.py
+
+formats:
+   - pdf
+   - epub
+
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,9 @@ from subprocess import PIPE, Popen
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["myst_parser"]
+extensions = [
+    "myst_parser",
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -69,7 +71,7 @@ else:
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,7 +79,8 @@ language = "en"
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = "sphinx"
+pygments_style = "default"
+pygments_dark_style = "lightbulb"
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,6 +32,7 @@ from subprocess import PIPE, Popen
 # ones.
 extensions = [
     "myst_parser",
+    "sphinx_copybutton",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -174,3 +175,8 @@ texinfo_documents = [
         "Miscellaneous",
     )
 ]
+
+
+# -- Options for Sphinx-copybutton -------------------------------------------
+
+copybutton_exclude = '.linenos, .gp, .go'

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-furo==2022.06.21
+furo==2023.9.10
 sphinx-autobuild
 myst-parser
 cogapp

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 furo==2023.9.10
 sphinx-autobuild
+sphinx-copybutton
 myst-parser
 cogapp


### PR DESCRIPTION
Fix #119 

- Upgrade Sphinx and fix doc build warnings
- Use higher contrast pygment styles
- Add Sphinx copy button extensions
- Add .readthedocs.yaml

<!-- readthedocs-preview shot-scraper start -->
----
:books: Documentation preview :books:: https://shot-scraper--120.org.readthedocs.build/en/120/

<!-- readthedocs-preview shot-scraper end -->