### PR TITLE
add a device option to specify device name for convenience

### DIFF
--- a/shot_scraper/cli.py
+++ b/shot_scraper/cli.py
@@ -127,7 +127,7 @@ def cli():
 @click.option(
     "-d",
     "--device",
-    help="playwright device name. Specify device name will override width height and retina option.",
+    help="Device name. Specify device name will override width height and retina option.",
 )
 @click.option(
     "-o",
@@ -391,6 +391,7 @@ def _browser_context(
     help="Path to JSON authentication context file",
 )
 @click.option("--retina", is_flag=True, help="Use device scale factor of 2")
+@click.option("--device", help="Device name. Specify device name will override retina option")
 @click.option(
     "--timeout",
     type=int,
@@ -425,6 +426,7 @@ def multi(
     config,
     auth,
     retina,
+    device,
     timeout,
     fail_on_error,
     noclobber,
@@ -466,6 +468,7 @@ def multi(
             user_agent=user_agent,
             timeout=timeout,
             reduced_motion=reduced_motion,
+            device=device
         )
         for shot in shots:
             if (

--- a/shot_scraper/utils.py
+++ b/shot_scraper/utils.py
@@ -12,7 +12,7 @@ def filename_for_url(url, ext=None, file_exists=file_exists_never):
     ext = ext or "png"
     bits = urllib.parse.urlparse(url)
     filename = (bits.netloc + bits.path).replace(".", "-").replace("/", "-").rstrip("-")
-    # Remove any characters outside of the allowed range
+    # Remove any characters outside the allowed range
     base_filename = disallowed_re.sub("", filename).lstrip("-")
     filename = base_filename + "." + ext
     suffix = 0


### PR DESCRIPTION
Device name is a built-in name according to [Playwright devices](https://playwright.dev/python/docs/api/class-playwright#playwright-devices
)

For example, specify `-d "iPhone 14 Prox Max"` will update `context_args` with
```python
{'default_browser_type': 'webkit',
 'device_scale_factor': 3,
 'has_touch': True,
 'is_mobile': True,
 'user_agent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) '
               'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 '
               'Mobile/15E148 Safari/604.1',
 'viewport': {'height': 740, 'width': 430}}
```

Specifying device name will override width, height, and retina options.

Using the device name to take screenshots on Apple devices is more convenient than manually specifying the width, height, and device_scale_factor.