### PR TITLE
Add a scale factor option

### DIFF
--- a/docs/multi.md
+++ b/docs/multi.md
@@ -31,9 +31,21 @@ The `url:` can be set to a path to a file on disk as well:
   url: index.html
 ```
 
+Use the `--scale-factor` option to capture all screenshots at a specific scale factor, which effectively simulates different device pixel ratios. This setting is useful for testing high-definition displays or emulating screens with various pixel densities.
+
+For example, setting `--scale-factor 3` results in screenshots with a CSS pixel ratio of 3, which is ideal for emulating a high-resolution display, such as Apple's iPhone 12 screens.
+
+To take screenshots with a scale factor of 3 (tripled resolution), run the following command:
+
+    shot-scraper multi shots.yml --scale-factor 3
+
+This will multiply both the width and height of all screenshots by 3, resulting in images with a higher level of detail, suitable for scenarios where you need to capture the screen as it would appear on a high-DPI display.
+
 Use `--retina` to take all screenshots at retina resolution instead, doubling the dimensions of the files:
 
     shot-scraper multi shots.yml --retina
+
+Note: The `--retina` option should not be used in conjunction with the `--scale-factor` flag as they are mutually exclusive. If both are provided, the command will raise an error to prevent conflicts.
 
 To take a screenshot of just the area of a page defined by a CSS selector, add `selector` to the YAML block:
 
@@ -130,7 +142,10 @@ Usage: shot-scraper multi [OPTIONS] CONFIG
 
 Options:
   -a, --auth FILENAME             Path to JSON authentication context file
-  --retina                        Use device scale factor of 2
+  --scale-factor FLOAT            Device scale factor. Cannot be used together
+                                  with '--retina'.
+  --retina                        Use device scale factor of 2. Cannot be used
+                                  together with '--scale-factor'.
   --timeout INTEGER               Wait this many milliseconds before failing
   -n, --no-clobber                Skip images that already exist
   -o, --output TEXT               Just take shots matching these output files

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -111,14 +111,31 @@ You can also use `--quality X` to save as a JPEG with the specified quality, in 
     % ls -lah simonwillison.jpg
     -rw-r--r--@ 1 simon  staff   168K Mar  9 13:53 simonwillison.jpg
 
+## Device scale factor
+
+The `--scale-factor` option sets a specific device scale factor, which effectively simulates different device pixel ratios. This setting is useful for testing high-definition displays or emulating screens with various pixel densities.
+
+For example, setting `--scale-factor 3` results in an image with a CSS pixel ratio of 3, which is ideal for emulating a high-resolution display, such as Apple iPhone 12 screens.
+
+To take a screenshot with a scale factor of 3 (tripled resolution), run the following command:
+
+    shot-scraper https://simonwillison.net/ -o simon.png \
+      --width 390 --height 844 --scale-factor 3
+
+This will multiply both the width and height of the screenshot by 3, resulting in an image that is 1170px wide and 2532px high, matching the iPhone 12's screen.
+
+The `--scale-factor` option takes a positive float as input. For example, setting `--scale-factor 2.625` simulates the Google Pixel 6's CSS pixel ratio.
+
 ## Retina images
 
-The `--retina` option sets a device scale factor of 2. This means that an image will have its resolution effectively doubled, emulating the display of images on [retina](https://en.wikipedia.org/wiki/Retina_display) or higher pixel density screens.
+The `--retina` option is a shortcut to set a device scale factor of 2. This means that an image will have its resolution effectively doubled, emulating the display of images on [retina](https://en.wikipedia.org/wiki/Retina_display) or higher pixel density screens.
 
     shot-scraper https://simonwillison.net/ -o simon.png \
       --width 400 --height 600 --retina
 
 This example will produce an image that is 800px wide and 1200px high.
+
+Note: The `--retina` option should not be used in conjunction with the `--scale-factor` flag as they are mutually exclusive. If both are provided, the command will raise an error to prevent conflicts.
 
 ## Transparent background
 
@@ -295,7 +312,10 @@ Options:
   -p, --padding INTEGER           When using selectors, add this much padding in
                                   pixels
   -j, --javascript TEXT           Execute this JS prior to taking the shot
-  --retina                        Use device scale factor of 2
+  --scale-factor FLOAT            Device scale factor. Cannot be used together
+                                  with '--retina'.
+  --retina                        Use device scale factor of 2. Cannot be used
+                                  together with '--scale-factor'.
   --omit-background               Omit the default browser background from the
                                   shot, making it possible take advantage of
                                   transparence. Does not work with JPEGs or when

--- a/tests/run_examples.sh
+++ b/tests/run_examples.sh
@@ -154,3 +154,9 @@ shot-scraper multi empty.yml
 ' | shot-scraper multi - --fail)
 # --bypass-csp
 shot-scraper javascript github.com "async () => { await import('https://cdn.jsdelivr.net/npm/left-pad/+esm'); return 'content-security-policy ignored' }" -o examples/github-csp.json --bypass-csp
+# --retina
+shot-scraper https://simonwillison.net/ -h 400 -w 800 \
+  -o examples/simonwillison-retina.png --retina
+# --scale-factor
+shot-scraper https://simonwillison.net/ -h 915 -w 412 \
+  -o examples/simonwillison-scale-factor-pixel-six.png --scale-factor 2.625

--- a/tests/test_shot_scraper.py
+++ b/tests/test_shot_scraper.py
@@ -120,3 +120,45 @@ def test_html(args, expected):
         assert result.exit_code == 0, result.output
         # Whitespace is not preserved
         assert result.output.replace("\n", "") == expected.replace("\n", "")
+
+
+@pytest.mark.parametrize(
+    "command,args,expected",
+    [
+        (
+            "shot",
+            ["--retina", "--scale-factor", 3],
+            "Error: --retina and --scale-factor cannot be used together\n",
+        ),
+        (
+            "multi",
+            ["--retina", "--scale-factor", 3],
+            "Error: --retina and --scale-factor cannot be used together\n",
+        ),
+        (
+            "shot",
+            ["--scale-factor", 0],
+            "Error: --scale-factor must be positive\n",
+        ),
+        (
+            "multi",
+            ["--scale-factor", 0],
+            "Error: --scale-factor must be positive\n",
+        ),
+        (
+            "shot",
+            ["--scale-factor", -3],
+            "Error: --scale-factor must be positive\n",
+        ),
+        (
+            "multi",
+            ["--scale-factor", -3],
+            "Error: --scale-factor must be positive\n",
+        ),
+    ],
+)
+def test_error_on_invalid_scale_factors(command, args, expected):
+    runner = CliRunner()
+    result = runner.invoke(cli, [command, "-"] + args)
+    assert result.exit_code == 1
+    assert result.output == expected


### PR DESCRIPTION
Adds the `--scale-factor` option.

Ref #136

The `--scale-factor` option allows users to specify a specific device scale factor as a float.

This is useful for testing specific high-definition displays. For example, the Google Pixel 6 has a pixel ratio of 2.625. Some modern phones have pixel ratios of 4.

I needed this for screenshots I'm taking, so thought it might be useful as a feature.

The existing `--retina` option is a specific case of the new `--scale-factor` option.

Includes a validation to prevent conflicts when using the `--scale-factor` and `--retina` options together. There is #129 that introduces the `--device` option with some overlap here. The `--device` option would also need to be mutually exclusive with `--scale-factor`.

<!-- readthedocs-preview shot-scraper start -->
----
📚 Documentation preview 📚: https://shot-scraper--133.org.readthedocs.build/en/133/

<!-- readthedocs-preview shot-scraper end -->