### PR TITLE
Set `max-width` on injected bounding box

### DIFF
--- a/shot_scraper/cli.py
+++ b/shot_scraper/cli.py
@@ -1305,6 +1305,7 @@ def _selector_javascript(selectors, selectors_all, padding=0):
         div.style.left = left + 'px';
         div.style.width = (right - left) + 'px';
         div.style.height = (bottom - top) + 'px';
+        div.style.maxWidth = 'none';
         div.setAttribute('id', %s);
         document.body.appendChild(div);
         setTimeout(() => {


### PR DESCRIPTION
[`max-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/max-width) of the injected element is set to `none`. Otherwise, the box can be too small if the page's CSS applies to the injected element by accident (e.g., `body > * { max-width: 5cm; }`).

<!-- readthedocs-preview shot-scraper start -->
----
📚 Documentation preview 📚: https://shot-scraper--143.org.readthedocs.build/en/143/

<!-- readthedocs-preview shot-scraper end -->