### PR TITLE
Fix "transparency" typo

### DIFF
--- a/shot_scraper/cli.py
+++ b/shot_scraper/cli.py
@@ -209,7 +209,7 @@ def cli():
 @click.option(
     "--omit-background",
     is_flag=True,
-    help="Omit the default browser background from the shot, making it possible take advantage of transparence. Does not work with JPEGs or when using --quality.",
+    help="Omit the default browser background from the shot, making it possible take advantage of transparency. Does not work with JPEGs or when using --quality.",
 )
 @click.option("--quality", type=int, help="Save as JPEG with this quality, e.g. 80")
 @click.option(


### PR DESCRIPTION
Whilst “transparence” [is technically an “    uncommon synonym of transparency”](https://en.wiktionary.org/wiki/transparence#English), I think using the common form is warranted.