### PR TITLE
Add support for --wait-for and --timeout to pdf command

### DIFF
--- a/docs/pdf.md
+++ b/docs/pdf.md
@@ -51,6 +51,8 @@ Options:
   -j, --javascript TEXT           Execute this JS prior to creating the PDF
   --wait INTEGER                  Wait this many milliseconds before taking the
                                   screenshot
+  --wait-for TEXT                 Wait until this JS expression returns true
+  --timeout INTEGER               Wait this many milliseconds before failing
   --media-screen                  Use screen rather than print styles
   --landscape                     Use landscape orientation
   --format [Letter|Legal|Tabloid|Ledger|A0|A1|A2|A3|A4|A5|A6]

--- a/shot_scraper/cli.py
+++ b/shot_scraper/cli.py
@@ -796,6 +796,12 @@ def javascript(
 @click.option(
     "--wait", type=int, help="Wait this many milliseconds before taking the screenshot"
 )
+@click.option("--wait-for", help="Wait until this JS expression returns true")
+@click.option(
+    "--timeout",
+    type=int,
+    help="Wait this many milliseconds before failing",
+)
 @click.option(
     "--media-screen", is_flag=True, help="Use screen rather than print styles"
 )
@@ -840,6 +846,8 @@ def pdf(
     output,
     javascript,
     wait,
+    wait_for,
+    timeout,
     media_screen,
     landscape,
     format_,
@@ -880,6 +888,7 @@ def pdf(
             bypass_csp=bypass_csp,
             auth_username=auth_username,
             auth_password=auth_password,
+            timeout=timeout,
         )
         page = context.new_page()
         if log_console:
@@ -890,6 +899,8 @@ def pdf(
             time.sleep(wait / 1000)
         if javascript:
             _evaluate_js(page, javascript)
+        if wait_for:
+            page.wait_for_function(wait_for)
 
         kwargs = {
             "landscape": landscape,


### PR DESCRIPTION
This PR adds the arguments `--wait-for` and `--timeout` to the `shot-scraper pdf` command to enable more nuanced waiting when generating PDFs.

I just copied the implementation from the shot method.

<!-- readthedocs-preview shot-scraper start -->
----
📚 Documentation preview 📚: https://shot-scraper--161.org.readthedocs.build/en/161/

<!-- readthedocs-preview shot-scraper end -->