### PR TITLE
Add --wait-until option to control navigation completion

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -35,16 +35,23 @@ Usage: shot-scraper accessibility [OPTIONS] URL
       shot-scraper accessibility https://datasette.io/
 
 Options:
-  -a, --auth FILENAME    Path to JSON authentication context file
+  -a, --auth FILENAME             Path to JSON authentication context file
   -o, --output FILENAME
-  -j, --javascript TEXT  Execute this JS prior to taking the snapshot
-  --timeout INTEGER      Wait this many milliseconds before failing
-  --log-console          Write console.log() to stderr
-  --fail                 Fail with an error code if a page returns an HTTP error
-  --skip                 Skip pages that return HTTP errors
-  --bypass-csp           Bypass Content-Security-Policy
-  --auth-password TEXT   Password for HTTP Basic authentication
-  --auth-username TEXT   Username for HTTP Basic authentication
-  --help                 Show this message and exit.
+  -j, --javascript TEXT           Execute this JS prior to taking the snapshot
+  --timeout INTEGER               Wait this many milliseconds before failing
+  --log-console                   Write console.log() to stderr
+  --fail                          Fail with an error code if a page returns an
+                                  HTTP error
+  --skip                          Skip pages that return HTTP errors
+  --bypass-csp                    Bypass Content-Security-Policy
+  --wait-until [commit|domcontentloaded|load|networkidle]
+                                  When to consider navigation succeeded, passed
+                                  to Playwright's page.goto(). Defaults to
+                                  'load'; use 'domcontentloaded' for single page
+                                  apps that hold open connections and never fire
+                                  the load event.
+  --auth-password TEXT            Password for HTTP Basic authentication
+  --auth-username TEXT            Username for HTTP Basic authentication
+  --help                          Show this message and exit.
 ```
 <!-- [[[end]]] -->

--- a/docs/har.md
+++ b/docs/har.md
@@ -113,21 +113,29 @@ Usage: shot-scraper har [OPTIONS] URL
   This creates /tmp/datasette.har and extracts resources to /tmp/datasette/
 
 Options:
-  -z, --zip              Save as a .har.zip file
-  -x, --extract          Extract resources from the HAR file into a directory
-  -a, --auth FILENAME    Path to JSON authentication context file
-  -o, --output FILE      HAR filename
-  --wait INTEGER         Wait this many milliseconds before taking the
-                         screenshot
-  --wait-for TEXT        Wait until this JS expression returns true
-  -j, --javascript TEXT  Execute this JavaScript on the page
-  --timeout INTEGER      Wait this many milliseconds before failing
-  --log-console          Write console.log() to stderr
-  --fail                 Fail with an error code if a page returns an HTTP error
-  --skip                 Skip pages that return HTTP errors
-  --bypass-csp           Bypass Content-Security-Policy
-  --auth-password TEXT   Password for HTTP Basic authentication
-  --auth-username TEXT   Username for HTTP Basic authentication
-  --help                 Show this message and exit.
+  -z, --zip                       Save as a .har.zip file
+  -x, --extract                   Extract resources from the HAR file into a
+                                  directory
+  -a, --auth FILENAME             Path to JSON authentication context file
+  -o, --output FILE               HAR filename
+  --wait INTEGER                  Wait this many milliseconds before taking the
+                                  screenshot
+  --wait-for TEXT                 Wait until this JS expression returns true
+  -j, --javascript TEXT           Execute this JavaScript on the page
+  --timeout INTEGER               Wait this many milliseconds before failing
+  --log-console                   Write console.log() to stderr
+  --fail                          Fail with an error code if a page returns an
+                                  HTTP error
+  --skip                          Skip pages that return HTTP errors
+  --bypass-csp                    Bypass Content-Security-Policy
+  --wait-until [commit|domcontentloaded|load|networkidle]
+                                  When to consider navigation succeeded, passed
+                                  to Playwright's page.goto(). Defaults to
+                                  'load'; use 'domcontentloaded' for single page
+                                  apps that hold open connections and never fire
+                                  the load event.
+  --auth-password TEXT            Password for HTTP Basic authentication
+  --auth-username TEXT            Username for HTTP Basic authentication
+  --help                          Show this message and exit.
 ```
 <!-- [[[end]]] -->

--- a/docs/html.md
+++ b/docs/html.md
@@ -72,6 +72,12 @@ Options:
                                   HTTP error
   --skip                          Skip pages that return HTTP errors
   --bypass-csp                    Bypass Content-Security-Policy
+  --wait-until [commit|domcontentloaded|load|networkidle]
+                                  When to consider navigation succeeded, passed
+                                  to Playwright's page.goto(). Defaults to
+                                  'load'; use 'domcontentloaded' for single page
+                                  apps that hold open connections and never fire
+                                  the load event.
   --silent                        Do not output any messages
   --auth-password TEXT            Password for HTTP Basic authentication
   --auth-username TEXT            Username for HTTP Basic authentication

--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -252,6 +252,12 @@ Options:
   --browser-arg TEXT              Additional arguments to pass to the browser
   --user-agent TEXT               User-Agent header to use
   --reduced-motion                Emulate 'prefers-reduced-motion' media feature
+  --wait-until [commit|domcontentloaded|load|networkidle]
+                                  When to consider navigation succeeded, passed
+                                  to Playwright's page.goto(). Defaults to
+                                  'load'; use 'domcontentloaded' for single page
+                                  apps that hold open connections and never fire
+                                  the load event.
   --log-console                   Write console.log() to stderr
   --fail                          Fail with an error code if a page returns an
                                   HTTP error

--- a/docs/multi.md
+++ b/docs/multi.md
@@ -246,6 +246,12 @@ Options:
   --browser-arg TEXT              Additional arguments to pass to the browser
   --user-agent TEXT               User-Agent header to use
   --reduced-motion                Emulate 'prefers-reduced-motion' media feature
+  --wait-until [commit|domcontentloaded|load|networkidle]
+                                  When to consider navigation succeeded, passed
+                                  to Playwright's page.goto(). Defaults to
+                                  'load'; use 'domcontentloaded' for single page
+                                  apps that hold open connections and never fire
+                                  the load event.
   --log-console                   Write console.log() to stderr
   --fail                          Fail with an error code if a page returns an
                                   HTTP error

--- a/docs/pdf.md
+++ b/docs/pdf.md
@@ -68,6 +68,12 @@ Options:
                                   HTTP error
   --skip                          Skip pages that return HTTP errors
   --bypass-csp                    Bypass Content-Security-Policy
+  --wait-until [commit|domcontentloaded|load|networkidle]
+                                  When to consider navigation succeeded, passed
+                                  to Playwright's page.goto(). Defaults to
+                                  'load'; use 'domcontentloaded' for single page
+                                  apps that hold open connections and never fire
+                                  the load event.
   --silent                        Do not output any messages
   --auth-password TEXT            Password for HTTP Basic authentication
   --auth-username TEXT            Username for HTTP Basic authentication

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -105,6 +105,19 @@ shot-scraper -h 800 'https://www.spiegel.de/international/' \
 ```
 If the expression takes longer than 30 seconds to resolve `shot-scraper` will exit with an error.
 
+## Controlling when navigation is considered complete
+
+By default `shot-scraper` waits for the browser's `load` event to fire before it continues. Some single page applications hold open long-lived connections (such as WebSockets or server-sent events) and never fire `load`, so navigation appears to hang until it times out.
+
+Use `--wait-until` to change the [Playwright navigation condition](https://playwright.dev/python/docs/api/class-page#page-goto-option-wait-until). For those pages `domcontentloaded` is usually the right choice:
+
+```bash
+shot-scraper 'https://my-single-page-app.example/' \
+  --wait-until domcontentloaded
+```
+
+The accepted values are `commit`, `domcontentloaded`, `load` (the default) and `networkidle`. This option is available on the `shot`, `multi`, `pdf`, `html`, `javascript`, `accessibility`, `har` and `video` commands.
+
 ## Executing custom JavaScript
 
 You can use custom JavaScript to modify the page after it has loaded (after the 'onload' event has fired) but before the screenshot is taken using the `--javascript` option:
@@ -366,6 +379,12 @@ Options:
   --browser-arg TEXT              Additional arguments to pass to the browser
   --user-agent TEXT               User-Agent header to use
   --reduced-motion                Emulate 'prefers-reduced-motion' media feature
+  --wait-until [commit|domcontentloaded|load|networkidle]
+                                  When to consider navigation succeeded, passed
+                                  to Playwright's page.goto(). Defaults to
+                                  'load'; use 'domcontentloaded' for single page
+                                  apps that hold open connections and never fire
+                                  the load event.
   --fail                          Fail with an error code if a page returns an
                                   HTTP error
   --skip                          Skip pages that return HTTP errors

--- a/docs/video.md
+++ b/docs/video.md
@@ -802,6 +802,12 @@ Options:
   --browser-arg TEXT              Additional arguments to pass to the browser
   --user-agent TEXT               User-Agent header to use
   --reduced-motion                Emulate 'prefers-reduced-motion' media feature
+  --wait-until [commit|domcontentloaded|load|networkidle]
+                                  When to consider navigation succeeded, passed
+                                  to Playwright's page.goto(). Defaults to
+                                  'load'; use 'domcontentloaded' for single page
+                                  apps that hold open connections and never fire
+                                  the load event.
   --log-console                   Write console.log() to stderr
   --fail                          Fail with an error code if a page returns an
                                   HTTP error

--- a/shot_scraper/cli.py
+++ b/shot_scraper/cli.py
@@ -158,6 +158,19 @@ def reduced_motion_option(fn):
     return fn
 
 
+def wait_until_option(fn):
+    click.option(
+        "--wait-until",
+        type=click.Choice(["commit", "domcontentloaded", "load", "networkidle"]),
+        help=(
+            "When to consider navigation succeeded, passed to Playwright's "
+            "page.goto(). Defaults to 'load'; use 'domcontentloaded' for single "
+            "page apps that hold open connections and never fire the load event."
+        ),
+    )(fn)
+    return fn
+
+
 @click.group(
     cls=DefaultGroup,
     default="shot",
@@ -266,6 +279,7 @@ def cli():
 @browser_args_option
 @user_agent_option
 @reduced_motion_option
+@wait_until_option
 @skip_fail_options
 @bypass_csp_option
 @silent_option
@@ -297,6 +311,7 @@ def shot(
     browser_args,
     user_agent,
     reduced_motion,
+    wait_until,
     skip,
     fail,
     bypass_csp,
@@ -348,6 +363,7 @@ def shot(
         "quality": quality,
         "wait": wait,
         "wait_for": wait_for,
+        "wait_until": wait_until,
         "timeout": timeout,
         "padding": padding,
         "omit_background": omit_background,
@@ -376,7 +392,7 @@ def shot(
             page = context.new_page()
             if width or height:
                 page.set_viewport_size(_get_viewport(width, height))
-            page.goto(url)
+            page.goto(url, wait_until=wait_until)
             context = page
             click.echo(
                 "Hit <enter> to take the shot and close the browser window:", err=True
@@ -500,6 +516,7 @@ def _browser_context(
 @browser_args_option
 @user_agent_option
 @reduced_motion_option
+@wait_until_option
 @log_console_option
 @skip_fail_options
 @bypass_csp_option
@@ -525,6 +542,7 @@ def video(
     browser_args,
     user_agent,
     reduced_motion,
+    wait_until,
     log_console,
     skip,
     fail,
@@ -652,6 +670,7 @@ def video(
             browser_args=browser_args,
             user_agent=user_agent,
             reduced_motion=reduced_motion,
+            wait_until=wait_until,
             log_console=log_console,
             skip=skip,
             fail=fail,
@@ -738,6 +757,7 @@ def _convert_video_to_mp4(output, silent=False):
 @browser_args_option
 @user_agent_option
 @reduced_motion_option
+@wait_until_option
 @log_console_option
 @skip_fail_options
 @silent_option
@@ -776,6 +796,7 @@ def multi(
     browser_args,
     user_agent,
     reduced_motion,
+    wait_until,
     log_console,
     skip,
     fail,
@@ -858,6 +879,9 @@ def multi(
                     server_processes.append(_start_server(shot["server"]))
                     time.sleep(1)
                 if "url" in shot:
+                    # CLI --wait-until is the default; a per-shot wait_until: in
+                    # the YAML takes precedence.
+                    shot.setdefault("wait_until", wait_until)
                     try:
                         take_shot(
                             context,
@@ -905,6 +929,7 @@ def multi(
 @log_console_option
 @skip_fail_options
 @bypass_csp_option
+@wait_until_option
 @http_auth_options
 def accessibility(
     url,
@@ -916,6 +941,7 @@ def accessibility(
     skip,
     fail,
     bypass_csp,
+    wait_until,
     auth_username,
     auth_password,
 ):
@@ -939,7 +965,7 @@ def accessibility(
         page = context.new_page()
         if log_console:
             page.on("console", console_log)
-        response = page.goto(url)
+        response = page.goto(url, wait_until=wait_until)
         skip_or_fail(response, skip, fail)
         if javascript:
             _evaluate_js(page, javascript)
@@ -985,6 +1011,7 @@ def accessibility(
 @log_console_option
 @skip_fail_options
 @bypass_csp_option
+@wait_until_option
 @http_auth_options
 def har(
     url,
@@ -1000,6 +1027,7 @@ def har(
     skip,
     fail,
     bypass_csp,
+    wait_until,
     auth_username,
     auth_password,
 ):
@@ -1045,7 +1073,7 @@ def har(
         page = context.new_page()
         if log_console:
             page.on("console", console_log)
-        response = page.goto(url)
+        response = page.goto(url, wait_until=wait_until)
         skip_or_fail(response, skip, fail)
         if wait:
             time.sleep(wait / 1000)
@@ -1210,6 +1238,7 @@ def _extract_har_entry(entry, extract_dir, existing_files, file_exists_fn, zip_f
 @browser_args_option
 @user_agent_option
 @reduced_motion_option
+@wait_until_option
 @log_console_option
 @skip_fail_options
 @bypass_csp_option
@@ -1227,6 +1256,7 @@ def javascript(
     browser_args,
     user_agent,
     reduced_motion,
+    wait_until,
     log_console,
     skip,
     fail,
@@ -1293,7 +1323,7 @@ def javascript(
         viewport = _get_viewport(width, height)
         if viewport:
             page.set_viewport_size(viewport)
-        response = page.goto(url)
+        response = page.goto(url, wait_until=wait_until)
         skip_or_fail(response, skip, fail)
         result = _evaluate_js(page, javascript)
         browser_obj.close()
@@ -1363,6 +1393,7 @@ def javascript(
 @log_console_option
 @skip_fail_options
 @bypass_csp_option
+@wait_until_option
 @silent_option
 @http_auth_options
 def pdf(
@@ -1384,6 +1415,7 @@ def pdf(
     skip,
     fail,
     bypass_csp,
+    wait_until,
     silent,
     auth_username,
     auth_password,
@@ -1418,7 +1450,7 @@ def pdf(
         page = context.new_page()
         if log_console:
             page.on("console", console_log)
-        response = page.goto(url)
+        response = page.goto(url, wait_until=wait_until)
         skip_or_fail(response, skip, fail)
         if wait:
             time.sleep(wait / 1000)
@@ -1480,6 +1512,7 @@ def pdf(
 @user_agent_option
 @skip_fail_options
 @bypass_csp_option
+@wait_until_option
 @silent_option
 @http_auth_options
 def html(
@@ -1496,6 +1529,7 @@ def html(
     skip,
     fail,
     bypass_csp,
+    wait_until,
     silent,
     auth_username,
     auth_password,
@@ -1528,7 +1562,7 @@ def html(
         page = context.new_page()
         if log_console:
             page.on("console", console_log)
-        response = page.goto(url)
+        response = page.goto(url, wait_until=wait_until)
         skip_or_fail(response, skip, fail)
         if wait:
             time.sleep(wait / 1000)
@@ -1691,6 +1725,7 @@ def _record_storyboard(
     browser_args=None,
     user_agent=None,
     reduced_motion=False,
+    wait_until=None,
     log_console=False,
     skip=False,
     fail=False,
@@ -1757,6 +1792,7 @@ def _record_storyboard(
                         start_url,
                         skip=skip,
                         fail=fail,
+                        wait_until=wait_until,
                     )
 
                 if storyboard_config.wait is not None:
@@ -1778,6 +1814,7 @@ def _record_storyboard(
                         skip=skip,
                         fail=fail,
                         silent=silent,
+                        wait_until=wait_until,
                     )
 
                 page.screencast.stop()
@@ -1804,7 +1841,9 @@ def _record_storyboard(
         click.echo(f"Video written to '{output}'", err=True)
 
 
-def _run_storyboard_scene(page, scene, index, skip=False, fail=False, silent=False):
+def _run_storyboard_scene(
+    page, scene, index, skip=False, fail=False, silent=False, wait_until=None
+):
     name = scene.name or f"Scene {index}"
     if not silent:
         click.echo(f"Scene {index}: {name}", err=True)
@@ -1815,18 +1854,20 @@ def _run_storyboard_scene(page, scene, index, skip=False, fail=False, silent=Fal
         _run_python_code(scene.python)
 
     if scene.open:
-        _storyboard_goto(page, scene.open, skip=skip, fail=fail)
+        _storyboard_goto(page, scene.open, skip=skip, fail=fail, wait_until=wait_until)
     if scene.wait_for:
         _storyboard_wait_for(page, scene.wait_for)
     if scene.wait_for_url:
         page.wait_for_url(scene.wait_for_url)
 
     for action_index, action in enumerate(scene.do, 1):
-        _run_storyboard_action(page, action, index, action_index, skip=skip, fail=fail)
+        _run_storyboard_action(
+            page, action, index, action_index, skip=skip, fail=fail, wait_until=wait_until
+        )
 
 
 def _run_storyboard_action(
-    page, action, scene_index, action_index, skip=False, fail=False
+    page, action, scene_index, action_index, skip=False, fail=False, wait_until=None
 ):
     if isinstance(action, ClickAction):
         click_kwargs = {}
@@ -1856,7 +1897,7 @@ def _run_storyboard_action(
     elif isinstance(action, WaitForUrlAction):
         page.wait_for_url(action.url)
     elif isinstance(action, OpenAction):
-        _storyboard_goto(page, action.url, skip=skip, fail=fail)
+        _storyboard_goto(page, action.url, skip=skip, fail=fail, wait_until=wait_until)
     elif isinstance(action, JavascriptAction):
         _evaluate_js(page, action.code)
     elif isinstance(action, ScreenshotAction):
@@ -1871,9 +1912,9 @@ def _run_storyboard_action(
         )
 
 
-def _storyboard_goto(page, url, skip=False, fail=False):
+def _storyboard_goto(page, url, skip=False, fail=False, wait_until=None):
     resolved_url = _resolve_storyboard_url(url, page.url)
-    response = page.goto(resolved_url)
+    response = page.goto(resolved_url, wait_until=wait_until)
     if response is not None:
         skip_or_fail(response, skip, fail)
 
@@ -2103,6 +2144,7 @@ def take_shot(
     omit_background = shot.get("omit_background")
     wait = shot.get("wait")
     wait_for = shot.get("wait_for")
+    wait_until = shot.get("wait_until")
     padding = shot.get("padding") or 0
 
     selectors = shot.get("selectors") or []
@@ -2157,7 +2199,7 @@ def take_shot(
 
     if not use_existing_page:
         # Load page and check for errors
-        response = page.goto(url)
+        response = page.goto(url, wait_until=wait_until)
         # Check if page was a 404 or 500 or other error
         if str(response.status)[0] in ("4", "5"):
             if skip:

--- a/tests/test_shot_scraper.py
+++ b/tests/test_shot_scraper.py
@@ -987,3 +987,82 @@ def test_har_extract_content_type_extension(http_server):
         assert (
             len(html_files) >= 1
         ), f"Should have .html file, got: {list(extract_dir.glob('*'))}"
+
+
+# --- --wait-until option -------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "command",
+    ("shot", "multi", "pdf", "html", "javascript", "accessibility", "har", "video"),
+)
+def test_wait_until_is_offered(command):
+    # Every URL-loading command exposes the --wait-until option
+    runner = CliRunner()
+    result = runner.invoke(cli, [command, "--help"])
+    assert result.exit_code == 0
+    assert "--wait-until" in result.output
+
+
+def test_wait_until_rejects_invalid_choice():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        open("index.html", "w").write(TEST_HTML)
+        result = runner.invoke(
+            cli, ["javascript", "index.html", "document.title", "--wait-until", "bogus"]
+        )
+    assert result.exit_code == 2
+    assert "not one of" in result.output
+
+
+def test_wait_until_end_to_end():
+    # A valid choice runs cleanly through the real navigation path
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        open("index.html", "w").write(TEST_HTML)
+        result = runner.invoke(
+            cli,
+            [
+                "javascript",
+                "index.html",
+                "document.title",
+                "--wait-until",
+                "domcontentloaded",
+            ],
+        )
+        assert result.exit_code == 0, str(result.exception)
+        assert result.output == '"Test title"\n'
+
+
+def test_wait_until_reaches_shot_dict(mocker):
+    # `shot`/`multi` navigate via take_shot(), which reads shot["wait_until"]
+    take = mocker.patch("shot_scraper.cli.take_shot")
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        open("index.html", "w").write(TEST_HTML)
+        result = runner.invoke(
+            cli,
+            ["shot", "index.html", "--wait-until", "networkidle", "-o", "out.png"],
+        )
+        assert result.exit_code == 0, str(result.exception)
+    assert take.call_args.args[1]["wait_until"] == "networkidle"
+
+
+def test_wait_until_reaches_storyboard_goto():
+    # The storyboard `video` path threads wait_until down to page.goto()
+    page = MagicMock()
+    page.url = "about:blank"
+    cli_module._storyboard_goto(
+        page, "https://example.com/", wait_until="domcontentloaded"
+    )
+    page.goto.assert_called_once_with(
+        "https://example.com/", wait_until="domcontentloaded"
+    )
+
+
+def test_goto_defaults_to_none_when_option_unset():
+    # Backwards compatible: no --wait-until => wait_until=None => Playwright default
+    page = MagicMock()
+    page.url = "about:blank"
+    cli_module._storyboard_goto(page, "https://example.com/")
+    page.goto.assert_called_once_with("https://example.com/", wait_until=None)


### PR DESCRIPTION
## What

Adds a `--wait-until` option to every URL-loading command (`shot`, `multi`, `pdf`, `html`, `javascript`, `accessibility`, `har` and `video`). The value is passed straight through to Playwright's [`page.goto(..., wait_until=...)`](https://playwright.dev/python/docs/api/class-page#page-goto-option-wait-until) and accepts `commit`, `domcontentloaded`, `load` (the default) and `networkidle`.

## Why

`shot-scraper` currently relies on Playwright's default `wait_until="load"`. Some single page apps hold open long-lived connections (WebSockets, server-sent events) and never fire the `load` event, so navigation hangs until it hits the timeout even though the page is fully usable. There's no way to change that today short of forking or monkeypatching.

With this change:

```bash
shot-scraper 'https://my-single-page-app.example/' --wait-until domcontentloaded
```

takes the shot as soon as the DOM is ready.

## Details

- New shared `wait_until_option` decorator next to the other option helpers.
- Threaded into each command's `page.goto()` call, including the full storyboard path for `video` (`_record_storyboard` → `_run_storyboard_scene` → `_run_storyboard_action` → `_storyboard_goto`).
- For `multi`, a per-shot `wait_until:` key in the YAML takes precedence over the CLI default (same pattern as the other per-shot keys).
- **Backwards compatible:** when the option is unset `wait_until` is `None`, which Playwright treats as its default (`load`), so existing behaviour is unchanged. There's a test asserting `page.goto` is still called with `wait_until=None` when the flag is omitted.
- I left the interactive `auth` command out, since it's a login-session bootstrap rather than a content fetch — happy to add it if you'd prefer full consistency.

## Tests & docs

- Added tests covering: the option is offered on all eight commands, invalid choices are rejected, an end-to-end run with `domcontentloaded`, and that the value propagates into both the `shot`/`take_shot` dict path and the storyboard `goto` path (plus the `None` default).
- Regenerated the `--help` docs with `cog -r docs/*.md` and added a short "Controlling when navigation is considered complete" section to `screenshots.md`.

All existing tests that pass on `main` in my environment still pass (the pre-existing `har`/`http.server` failures are unrelated environment issues and fail identically without this change).


<!-- readthedocs-preview shot-scraper start -->
----
📚 Documentation preview 📚: https://shot-scraper--199.org.readthedocs.build/en/199/

<!-- readthedocs-preview shot-scraper end -->