### PR TITLE
Add a Dockerfile for running shot-scraper with only Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.venv
+venv
+**/__pycache__
+*.pyc
+.pytest_cache
+docs/_build
+test-artifacts
+*.webm
+*.mp4
+*.png

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,52 @@
+# Run shot-scraper with only Docker installed on the host: chromium, its system
+# libraries, ffmpeg, espeak-ng, the Kokoro narration model and shot-scraper all
+# live in the image.
+#
+#   docker build -t shot-scraper .
+#
+#   # Screenshot (mount the current directory as /work for inputs/outputs):
+#   docker run --rm -v "$PWD:/work" shot-scraper \
+#     shot https://example.com/ -o /work/example.png \
+#     --browser-arg --no-sandbox --browser-arg --disable-dev-shm-usage
+#
+#   # Narrated video:
+#   docker run --rm -v "$PWD:/work" shot-scraper \
+#     video /work/storyboard.yml -o /work/demo.webm --mp4 \
+#     --browser-arg --no-sandbox --browser-arg --disable-dev-shm-usage
+#
+# chromium cannot use its sandbox as root inside a container, and the default
+# 64MB /dev/shm is too small, so pass --browser-arg --no-sandbox and
+# --browser-arg --disable-dev-shm-usage (shown above). On Linux add
+# `--network host` to reach a server on the host's own localhost.
+FROM python:3.12-slim
+
+# ffmpeg/ffprobe (--mp4 and narration muxing) and espeak-ng (Kokoro phonemizer).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ffmpeg espeak-ng \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install shot-scraper with the narration extra from the build context, then the
+# matching Playwright chromium + its system libraries (pinned by shot-scraper's
+# own Playwright dependency, so the browser never drifts from the library).
+COPY . /src
+RUN pip install --no-cache-dir "/src[narrate]"
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+RUN python -m playwright install --with-deps chromium \
+    && chmod -R a+rx /ms-playwright
+
+# Bake the Kokoro model + voices so narration works fully offline. This matches
+# narration.py's default cache location ($XDG_CACHE_HOME/shot-scraper/kokoro).
+ENV XDG_CACHE_HOME=/cache
+RUN mkdir -p /cache/shot-scraper/kokoro && python - <<'PY'
+import pathlib
+import urllib.request
+
+base = "https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0"
+dest = pathlib.Path("/cache/shot-scraper/kokoro")
+for name in ("kokoro-v1.0.onnx", "voices-v1.0.bin"):
+    urllib.request.urlretrieve(f"{base}/{name}", dest / name)
+PY
+RUN chmod -R a+rX /cache
+
+WORKDIR /work
+ENTRYPOINT ["shot-scraper"]

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,6 +24,33 @@ If you want to use other browsers such as Firefox you should install those too:
 shot-scraper install -b firefox
 ```
 
+(installation-docker)=
+
+## Running with Docker
+
+The repository includes a `Dockerfile` that packages shot-scraper together with Chromium, its system libraries, `ffmpeg`, `espeak-ng` and the Kokoro narration model, so the only thing the host needs is Docker.
+
+Build the image:
+```bash
+docker build -t shot-scraper .
+```
+
+Then mount a directory as `/work` for inputs and outputs. Chromium cannot use its sandbox as root inside a container, so pass `--no-sandbox` (and `--disable-dev-shm-usage`, since the default 64MB `/dev/shm` is too small) via `--browser-arg`:
+```bash
+docker run --rm -v "$PWD:/work" shot-scraper \
+  shot https://example.com/ -o /work/example.png \
+  --browser-arg --no-sandbox --browser-arg --disable-dev-shm-usage
+```
+
+Recording a {ref}`narrated video <video>` works fully offline — the Kokoro model is baked into the image:
+```bash
+docker run --rm -v "$PWD:/work" shot-scraper \
+  video /work/storyboard.yml -o /work/demo.webm --mp4 \
+  --browser-arg --no-sandbox --browser-arg --disable-dev-shm-usage
+```
+
+To reach a server running on the host's own `localhost`, add `--network host` (Linux) or point the storyboard `url:` at `http://host.docker.internal:PORT/` (Docker Desktop on macOS/Windows).
+
 ## `shot-scraper install --help`
 
 Full `--help` for the `shot-scraper install` command:

--- a/docs/video.md
+++ b/docs/video.md
@@ -671,6 +671,52 @@ scenes:
   - pause: 2
 ```
 
+## Narration
+
+A scene can carry a `say:` line of spoken narration. When any scene has one, `shot-scraper video ... --mp4` synthesizes each line to speech, holds each frame long enough for its line to finish, and mixes the audio into the MP4:
+
+```yaml
+url: https://shot-scraper.datasette.io/
+narration:
+  voice: af_heart
+scenes:
+- say: This is the shot-scraper documentation homepage.
+  do:
+    - pause: 1
+- say: Clicking through takes us to the screenshots guide.
+  do:
+    - click: "a[href$='screenshots.html']"
+    - wait_for: "h1"
+```
+
+```bash
+shot-scraper video narrated.yml -o demo.webm --mp4
+```
+
+This writes the silent `demo.webm` and a narrated `demo.mp4`. Narration is *audio-led*: the pause after each scene is sized from the measured length of its spoken line, so the words and the visuals cannot drift apart. Because the audio lives in the MP4, `say:` requires `--mp4`.
+
+Speech is generated **offline** with [Kokoro](https://github.com/thewh1teagle/kokoro-onnx) on the CPU — no network or API key at render time (the model is downloaded and cached on first use). Install the extra dependencies and their system requirements:
+
+```bash
+pip install shot-scraper[narrate]
+# ffmpeg (also needed for --mp4) and espeak-ng must be on PATH:
+#   macOS:         brew install ffmpeg espeak-ng
+#   Debian/Ubuntu: sudo apt-get install ffmpeg espeak-ng
+```
+
+Narration is tuned with an optional top-level `narration:` mapping:
+
+| Key | Default | Meaning |
+| --- | --- | --- |
+| `voice` | `af_heart` | Kokoro voice id |
+| `speed` | `1.0` | Speech rate |
+| `action_allowance` | `1.0` | Seconds budgeted for a scene's actions before its line speaks (override per-scene with `action_allowance:` on the scene) |
+| `lead` | `0.4` | Settle pause before a line starts speaking |
+| `buffer` | `0.6` | Held still-frame after each line |
+| `model` / `voices` | auto | Explicit paths to the Kokoro model files |
+
+If a line starts too early or late over its shot, increase that scene's `action_allowance` and re-render.
+
 ## Command options
 
 `shot-scraper video` supports the same browser selection, authentication, console logging, timeout, CSP bypass and HTTP Basic authentication options as the other browser-based commands.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,14 @@ dependencies = [
     "click-default-group",
 ]
 
+[project.optional-dependencies]
+# Spoken narration for `shot-scraper video` (say: lines). Also needs a system
+# ffmpeg/ffprobe and espeak-ng.
+narrate = [
+    "kokoro-onnx",
+    "soundfile",
+]
+
 [project.urls]
 Homepage = "https://shot-scraper.datasette.io/"
 Issues = "https://github.com/simonw/shot-scraper/issues"

--- a/shot_scraper/cli.py
+++ b/shot_scraper/cli.py
@@ -2,6 +2,7 @@ import base64
 import secrets
 import subprocess
 import sys
+import tempfile
 import textwrap
 import time
 import json
@@ -32,6 +33,11 @@ from shot_scraper.video import (
     WaitForAction,
     WaitForUrlAction,
     load_storyboard,
+)
+from shot_scraper.narration import (
+    NarrationError,
+    mux_narration,
+    plan_narration,
 )
 from shot_scraper.utils import (
     filename_for_url,
@@ -643,6 +649,27 @@ def video(
         raise click.ClickException(str(ex))
     if output:
         storyboard_config = storyboard_config.model_copy(update={"output": output})
+
+    # Narration: any scene with a say: line is synthesized to speech, the
+    # storyboard is padded to hold each frame for its line, and the audio is
+    # muxed into the MP4. It therefore requires --mp4.
+    narration_lines = None
+    narration_tmp = None
+    if storyboard_config.has_narration():
+        if not mp4:
+            raise click.ClickException(
+                "This storyboard has say: narration, which is rendered into the "
+                "MP4 audio track — re-run with --mp4."
+            )
+        narration_tmp = tempfile.TemporaryDirectory(prefix="shot-scraper-narration-")
+        try:
+            narration_lines = plan_narration(
+                storyboard_config, pathlib.Path(narration_tmp.name) / "audio"
+            )
+        except NarrationError as ex:
+            narration_tmp.cleanup()
+            raise click.ClickException(str(ex))
+
     try:
         _record_storyboard(
             storyboard_config,
@@ -662,9 +689,27 @@ def video(
             leave_server=leave_server,
         )
         if mp4:
-            _convert_video_to_mp4(storyboard_config.output, silent=silent)
+            if narration_lines:
+                mp4_output = str(
+                    pathlib.Path(storyboard_config.output).with_suffix(".mp4")
+                )
+                try:
+                    mux_narration(
+                        pathlib.Path(storyboard_config.output),
+                        pathlib.Path(mp4_output),
+                        narration_lines,
+                    )
+                except NarrationError as ex:
+                    raise click.ClickException(str(ex))
+                if not silent:
+                    click.echo(f"Narrated MP4 written to '{mp4_output}'", err=True)
+            else:
+                _convert_video_to_mp4(storyboard_config.output, silent=silent)
     except TimeoutError as e:
         raise click.ClickException(str(e))
+    finally:
+        if narration_tmp is not None:
+            narration_tmp.cleanup()
 
 
 def _convert_video_to_mp4(output, silent=False):

--- a/shot_scraper/narration.py
+++ b/shot_scraper/narration.py
@@ -1,0 +1,292 @@
+"""Spoken narration for ``shot-scraper video`` storyboards.
+
+A storyboard scene may carry a ``say:`` line. When any scene does,
+``shot-scraper video ... --mp4`` produces a *narrated* MP4:
+
+1.  Each ``say:`` line is synthesized to speech offline with Kokoro (via the
+    ``kokoro-onnx`` package, CPU-only), and its real duration is measured with
+    ``ffprobe``.
+2.  A trailing ``pause`` is appended to that scene, long enough to hold the
+    frame for the whole spoken line, so narration is never clipped by the next
+    scene. This is *audio-led*: the video timing is derived from the measured
+    speech, so the two cannot drift apart.
+3.  After the silent video is recorded, each clip is laid onto a full-length
+    silent bed at its computed start offset (ffmpeg ``adelay``/``amix``) and
+    muxed into the MP4.
+
+``kokoro-onnx`` and ``soundfile`` are optional; install them with
+``pip install shot-scraper[narrate]``. ``ffmpeg``/``ffprobe`` must be on PATH
+(the same requirement as ``--mp4``). Nothing here touches a GPU.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+# Kokoro's native output sample rate.
+KOKORO_SAMPLE_RATE = 24000
+
+# Where model files are cached / downloaded to when not supplied explicitly.
+KOKORO_MODEL_BASE = (
+    "https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0"
+)
+KOKORO_MODEL_NAME = "kokoro-v1.0.onnx"
+KOKORO_VOICES_NAME = "voices-v1.0.bin"
+
+# Common locations for a *system* espeak-ng library + its data. kokoro-onnx
+# bundles espeakng-loader, but that prebuilt dylib has a data path baked in at
+# build time that often does not exist locally ("phontab: No such file or
+# directory"). A system espeak-ng (brew on macOS, apt on Linux) has a correct,
+# self-consistent data path, so we prefer it when present.
+_ESPEAK_LIB_CANDIDATES = [
+    "/opt/homebrew/lib/libespeak-ng.dylib",  # macOS arm64 (brew)
+    "/usr/local/lib/libespeak-ng.dylib",  # macOS x86_64 (brew)
+    "/usr/lib/x86_64-linux-gnu/libespeak-ng.so.1",  # Debian/Ubuntu
+    "/usr/lib/libespeak-ng.so.1",  # other Linux
+    "/usr/lib/aarch64-linux-gnu/libespeak-ng.so.1",  # arm64 Linux
+]
+_ESPEAK_DATA_CANDIDATES = [
+    "/opt/homebrew/share/espeak-ng-data",
+    "/usr/local/share/espeak-ng-data",
+    "/usr/share/espeak-ng-data",
+    "/usr/lib/x86_64-linux-gnu/espeak-ng-data",
+    "/usr/lib/aarch64-linux-gnu/espeak-ng-data",
+]
+
+
+class NarrationError(Exception):
+    """Raised for any narration setup or synthesis failure."""
+
+
+@dataclass
+class NarrationLine:
+    """One synthesized ``say:`` line, placed on the final video timeline."""
+
+    name: str
+    wav: Path
+    duration: float  # measured length of the spoken audio, seconds
+    start: float  # offset into the final video where the line begins speaking
+    mid: float  # midpoint of the line (handy for a verification still)
+
+
+def _run(args: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(args, check=True, text=True, capture_output=True)
+
+
+def probe_duration(path: Path) -> float:
+    """Return the duration of an audio/video file in seconds via ffprobe."""
+    try:
+        result = _run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-show_entries",
+                "format=duration",
+                "-of",
+                "default=nw=1:nk=1",
+                str(path),
+            ]
+        )
+    except FileNotFoundError:
+        raise NarrationError(
+            "ffprobe is not installed or not on PATH (needed for narration)."
+        )
+    except subprocess.CalledProcessError as ex:
+        raise NarrationError(f"ffprobe failed for {path}: {ex.stderr or ex.stdout}")
+    return float(result.stdout.strip())
+
+
+def default_model_dir() -> Path:
+    root = os.environ.get("XDG_CACHE_HOME") or str(Path.home() / ".cache")
+    return Path(root) / "shot-scraper" / "kokoro"
+
+
+def _ensure_model_files(model: Path, voices: Path) -> None:
+    """Download the Kokoro model/voices if absent (idempotent, best-effort)."""
+    for path, name in ((model, KOKORO_MODEL_NAME), (voices, KOKORO_VOICES_NAME)):
+        if path.exists() and path.stat().st_size > 0:
+            continue
+        url = f"{KOKORO_MODEL_BASE}/{name}"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        sys.stderr.write(f"Downloading Kokoro model {name} -> {path} ...\n")
+        try:
+            urllib.request.urlretrieve(url, path)
+        except Exception as exc:
+            raise NarrationError(
+                f"Failed to download {name} from {url}: {exc}\n"
+                "Download it manually and pass narration model:/voices: paths."
+            ) from exc
+
+
+def _find_system_espeak():
+    """Return (lib_path, data_path) for a usable system espeak-ng, or None."""
+    lib = next((p for p in _ESPEAK_LIB_CANDIDATES if Path(p).exists()), None)
+    data = next(
+        (p for p in _ESPEAK_DATA_CANDIDATES if Path(p, "phontab").exists()), None
+    )
+    if lib and data:
+        return lib, data
+    return None
+
+
+def load_kokoro(model: Path | None = None, voices: Path | None = None):
+    """Load a Kokoro synthesizer, downloading the model files if needed."""
+    try:
+        from kokoro_onnx import Kokoro
+    except ImportError as exc:
+        raise NarrationError(
+            "Narration needs the 'kokoro-onnx' package. Install the extra with:\n"
+            "  pip install shot-scraper[narrate]\n"
+            "(also requires espeak-ng: 'brew install espeak-ng' on macOS, "
+            "'sudo apt-get install espeak-ng' on Debian/Ubuntu)."
+        ) from exc
+
+    model = Path(model) if model else default_model_dir() / KOKORO_MODEL_NAME
+    voices = Path(voices) if voices else default_model_dir() / KOKORO_VOICES_NAME
+    _ensure_model_files(model, voices)
+
+    # Force CPU: never contend with a GPU that may be busy.
+    os.environ.setdefault("ONNX_PROVIDER", "CPUExecutionProvider")
+
+    espeak = _find_system_espeak()
+    if espeak:
+        from kokoro_onnx import EspeakConfig
+
+        lib, data = espeak
+        return Kokoro(
+            str(model),
+            str(voices),
+            espeak_config=EspeakConfig(lib_path=lib, data_path=data),
+        )
+
+    sys.stderr.write(
+        "WARNING: no system espeak-ng found; relying on the bundled loader, "
+        "which may fail. Install espeak-ng if synthesis errors.\n"
+    )
+    return Kokoro(str(model), str(voices))
+
+
+def synth_line(kokoro, text: str, voice: str, speed: float, out_path: Path) -> None:
+    try:
+        import soundfile as sf
+    except ImportError as exc:
+        raise NarrationError(
+            "Narration needs 'soundfile'. Install with: pip install shot-scraper[narrate]"
+        ) from exc
+
+    samples, sample_rate = kokoro.create(text, voice=voice, speed=speed, lang="en-us")
+    sf.write(str(out_path), samples, sample_rate)
+
+
+def plan_narration(storyboard, audio_dir: Path, narrator=None) -> list[NarrationLine]:
+    """Synthesize every scene ``say:`` line and append frame-holding pauses.
+
+    Mutates each narrated scene's ``do`` list in place (appending a ``pause``
+    action sized to hold the frame for the whole spoken line) and returns the
+    timeline placement of each line. ``storyboard.scenes`` must already be the
+    validated pydantic model. Pass ``narrator`` to reuse a loaded Kokoro (tests
+    inject a fake); otherwise one is loaded from the storyboard's narration
+    options.
+    """
+    from .video import PauseAction  # local import to avoid a cycle
+
+    opts = storyboard.narration
+    audio_dir.mkdir(parents=True, exist_ok=True)
+    if narrator is None:
+        narrator = load_kokoro(opts.model, opts.voices)
+
+    lines: list[NarrationLine] = []
+    cursor = 0.0  # running position in the final video, seconds
+    for index, scene in enumerate(storyboard.scenes):
+        allowance = (
+            scene.action_allowance
+            if scene.action_allowance is not None
+            else opts.action_allowance
+        )
+        if scene.say:
+            wav = audio_dir / f"{index:02d}.wav"
+            synth_line(narrator, scene.say, opts.voice, opts.speed, wav)
+            duration = probe_duration(wav)
+            # Timeline within the scene:
+            #   [actions ~allowance] [lead settle] [speak duration] [buffer]
+            start = cursor + allowance + opts.lead
+            hold = opts.lead + duration + opts.buffer
+            lines.append(
+                NarrationLine(
+                    name=scene.name or f"Scene {index + 1}",
+                    wav=wav,
+                    duration=round(duration, 3),
+                    start=round(start, 3),
+                    mid=round(start + duration / 2, 3),
+                )
+            )
+            scene.do.append(PauseAction(action="pause", seconds=round(hold, 3)))
+            cursor += allowance + hold
+        else:
+            explicit_pause = sum(
+                action.seconds
+                for action in scene.do
+                if isinstance(action, PauseAction)
+            )
+            cursor += allowance + explicit_pause
+    return lines
+
+
+def mux_narration(video: Path, output: Path, lines: list[NarrationLine]) -> None:
+    """Mix each narration clip onto the recorded video at its start offset."""
+    if not lines:
+        raise NarrationError("mux_narration called with no narration lines")
+    video_dur = probe_duration(video)
+
+    inputs: list[str] = ["-i", str(video)]
+    filters: list[str] = []
+    labels: list[str] = []
+    for i, line in enumerate(lines):
+        inputs += ["-i", str(line.wav)]
+        delay_ms = int(round(line.start * 1000))
+        end = line.start + line.duration
+        if end > video_dur + 0.05:
+            sys.stderr.write(
+                f"WARNING: narration line {i} ('{line.name}') ends at {end:.1f}s "
+                f"but the video is only {video_dur:.1f}s — it will be cut off. "
+                "Increase that scene's action_allowance or shorten the line.\n"
+            )
+        # Audio stream index is i + 1 (0 is the video).
+        filters.append(f"[{i + 1}:a]adelay={delay_ms}|{delay_ms}[a{i}]")
+        labels.append(f"[a{i}]")
+
+    mix = "".join(labels) + f"amix=inputs={len(labels)}:normalize=0[aout]"
+    filter_complex = ";".join(filters + [mix])
+    cmd = (
+        ["ffmpeg", "-y"]
+        + inputs
+        + [
+            "-filter_complex",
+            filter_complex,
+            "-map",
+            "0:v",
+            "-map",
+            "[aout]",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            "-movflags",
+            "+faststart",
+            "-c:a",
+            "aac",
+            str(output),
+        ]
+    )
+    try:
+        _run(cmd)
+    except FileNotFoundError:
+        raise NarrationError("ffmpeg is not installed or not on PATH.")
+    except subprocess.CalledProcessError as ex:
+        raise NarrationError(f"ffmpeg mux failed: {ex.stderr or ex.stdout}")

--- a/shot_scraper/video.py
+++ b/shot_scraper/video.py
@@ -34,6 +34,21 @@ class CursorOptions(StoryboardBaseModel):
     click_size: PositiveInt = 44
 
 
+class NarrationOptions(StoryboardBaseModel):
+    # Kokoro voice id and speech rate.
+    voice: str = "af_heart"
+    speed: float = 1.0
+    # Seconds budgeted for a scene's actions before its line starts speaking.
+    action_allowance: NonNegativeFloat = 1.0
+    # Settle pause before a line speaks, so the UI has come to rest.
+    lead: NonNegativeFloat = 0.4
+    # Held still-frame after each line, absorbing small action-time variance.
+    buffer: NonNegativeFloat = 0.6
+    # Optional explicit Kokoro model/voices paths (else cached/downloaded).
+    model: str | None = None
+    voices: str | None = None
+
+
 class ClickAction(StoryboardBaseModel):
     action: Literal["click"]
     selector: str
@@ -176,6 +191,10 @@ class StoryboardScene(StoryboardBaseModel):
     wait_for_url: str | None = None
     sh: str | list[str] | None = None
     python: str | None = None
+    # Spoken narration for this scene (rendered with --mp4).
+    say: str | None = None
+    # Per-scene override of narration.action_allowance.
+    action_allowance: NonNegativeFloat | None = None
     do: list[StoryboardAction] = Field(default_factory=list)
 
     @field_validator("do", mode="before")
@@ -200,6 +219,7 @@ class Storyboard(StoryboardBaseModel):
     wait_for: str | None = None
     wait_for_url: str | None = None
     javascript: str | None = None
+    narration: NarrationOptions = Field(default_factory=NarrationOptions)
     scenes: list[StoryboardScene] = Field(default_factory=list)
 
     @field_validator("cursor", mode="before")
@@ -223,6 +243,9 @@ class Storyboard(StoryboardBaseModel):
         width = self.viewport.width or 1280
         height = self.viewport.height or 720
         return {"width": width, "height": height}
+
+    def has_narration(self):
+        return any(scene.say for scene in self.scenes)
 
 
 def load_storyboard(storyboard_file):

--- a/tests/test_narration.py
+++ b/tests/test_narration.py
@@ -1,0 +1,154 @@
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from shot_scraper import narration
+from shot_scraper.cli import cli
+from shot_scraper.video import PauseAction, Storyboard, StoryboardError, load_storyboard
+
+
+def _story(scenes, **narration_opts):
+    data = {"url": "https://example.com/", "scenes": scenes}
+    if narration_opts:
+        data["narration"] = narration_opts
+    return Storyboard.model_validate(data)
+
+
+# --- storyboard model ----------------------------------------------------- #
+
+
+def test_say_field_parses():
+    story = _story([{"say": "hello world", "do": []}])
+    assert story.has_narration()
+    assert story.scenes[0].say == "hello world"
+
+
+def test_storyboard_without_say_has_no_narration():
+    story = _story([{"do": [{"pause": 1}]}])
+    assert not story.has_narration()
+
+
+def test_narration_options_parse():
+    story = _story([{"say": "hi", "do": []}], voice="am_adam", speed=1.2, lead=0.2)
+    assert story.narration.voice == "am_adam"
+    assert story.narration.speed == 1.2
+    assert story.narration.lead == 0.2
+    # Untouched options keep their defaults
+    assert story.narration.buffer == 0.6
+
+
+def test_unknown_scene_key_still_forbidden():
+    import io
+
+    bad = "url: https://example.com/\nscenes:\n- say: hi\n  bogus: 1\n  do: []\n"
+    with pytest.raises(StoryboardError):
+        load_storyboard(io.StringIO(bad))
+
+
+# --- planning (synthesis + pause injection + timeline) -------------------- #
+
+
+def test_plan_narration_injects_pause_and_computes_offsets(mocker, tmp_path):
+    mocker.patch("shot_scraper.narration.synth_line")
+    mocker.patch("shot_scraper.narration.probe_duration", return_value=2.0)
+    story = _story(
+        [
+            {"name": "one", "say": "first line", "do": [{"click": "#a"}]},
+            {"name": "two", "say": "second line", "do": []},
+        ]
+    )
+    lines = narration.plan_narration(story, tmp_path / "audio", narrator=MagicMock())
+
+    assert [line.name for line in lines] == ["one", "two"]
+    # hold = lead + duration + buffer = 0.4 + 2.0 + 0.6 = 3.0, appended to each scene
+    assert isinstance(story.scenes[0].do[-1], PauseAction)
+    assert story.scenes[0].do[-1].seconds == 3.0
+    assert isinstance(story.scenes[1].do[-1], PauseAction)
+    # scene 0 line starts at allowance + lead = 1.0 + 0.4
+    assert lines[0].start == 1.4
+    # cursor after scene 0 = allowance + hold = 1.0 + 3.0 = 4.0; scene 1 at +1.4
+    assert lines[1].start == 5.4
+    assert lines[0].mid == round(1.4 + 2.0 / 2, 3)
+
+
+def test_plan_narration_per_scene_action_allowance(mocker, tmp_path):
+    mocker.patch("shot_scraper.narration.synth_line")
+    mocker.patch("shot_scraper.narration.probe_duration", return_value=1.0)
+    story = _story([{"say": "x", "action_allowance": 3, "do": []}])
+    lines = narration.plan_narration(story, tmp_path / "audio", narrator=MagicMock())
+    # start = action_allowance (3) + lead (0.4)
+    assert lines[0].start == 3.4
+
+
+def test_plan_narration_silent_scene_advances_by_pauses(mocker, tmp_path):
+    mocker.patch("shot_scraper.narration.synth_line")
+    mocker.patch("shot_scraper.narration.probe_duration", return_value=1.0)
+    story = _story(
+        [
+            {"do": [{"pause": 2}]},  # silent: allowance(1) + pause(2) = 3
+            {"say": "after", "do": []},
+        ]
+    )
+    lines = narration.plan_narration(story, tmp_path / "audio", narrator=MagicMock())
+    # cursor after silent scene = 3.0; line starts at 3.0 + allowance(1) + lead(0.4)
+    assert lines[0].start == 4.4
+
+
+# --- muxing --------------------------------------------------------------- #
+
+
+def test_mux_narration_builds_ffmpeg_command(mocker, tmp_path):
+    run = mocker.patch("shot_scraper.narration._run")
+    mocker.patch("shot_scraper.narration.probe_duration", return_value=10.0)
+    lines = [
+        narration.NarrationLine(
+            name="a", wav=tmp_path / "0.wav", duration=2.0, start=1.4, mid=2.4
+        )
+    ]
+    narration.mux_narration(tmp_path / "in.webm", tmp_path / "out.mp4", lines)
+    args = run.call_args.args[0]
+    assert args[0] == "ffmpeg"
+    filter_complex = args[args.index("-filter_complex") + 1]
+    assert "adelay=1400|1400" in filter_complex
+    assert "amix=inputs=1:normalize=0" in filter_complex
+    assert args[-1] == str(tmp_path / "out.mp4")
+
+
+def test_mux_narration_warns_when_line_overruns_video(mocker, tmp_path, capsys):
+    mocker.patch("shot_scraper.narration._run")
+    mocker.patch("shot_scraper.narration.probe_duration", return_value=10.0)
+    lines = [
+        narration.NarrationLine(
+            name="tail", wav=tmp_path / "0.wav", duration=5.0, start=8.0, mid=10.5
+        )
+    ]
+    narration.mux_narration(tmp_path / "in.webm", tmp_path / "out.mp4", lines)
+    assert "will be cut off" in capsys.readouterr().err
+
+
+# --- CLI wiring ----------------------------------------------------------- #
+
+STORYBOARD_YAML = "url: https://example.com/\nscenes:\n- say: hello\n  do: []\n"
+
+
+def test_video_narration_requires_mp4():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        open("sb.yml", "w").write(STORYBOARD_YAML)
+        result = runner.invoke(cli, ["video", "sb.yml"])
+    assert result.exit_code != 0
+    assert "--mp4" in result.output
+
+
+def test_video_narration_error_becomes_clickexception(mocker):
+    mocker.patch(
+        "shot_scraper.cli.plan_narration",
+        side_effect=narration.NarrationError("kokoro-onnx is not installed"),
+    )
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        open("sb.yml", "w").write(STORYBOARD_YAML)
+        result = runner.invoke(cli, ["video", "sb.yml", "--mp4"])
+    assert result.exit_code != 0
+    assert "kokoro-onnx is not installed" in result.output


### PR DESCRIPTION
## What

Adds a `Dockerfile` (plus `.dockerignore`) that packages shot-scraper together with everything it needs at runtime — Chromium and its system libraries, `ffmpeg`/`ffprobe`, `espeak-ng`, and the baked-in Kokoro model — so the only thing the host needs is Docker.

```bash
docker build -t shot-scraper .

# Screenshot:
docker run --rm -v "$PWD:/work" shot-scraper \
  shot https://example.com/ -o /work/example.png \
  --browser-arg --no-sandbox --browser-arg --disable-dev-shm-usage

# Fully-offline narrated video:
docker run --rm -v "$PWD:/work" shot-scraper \
  video /work/storyboard.yml -o /work/demo.webm --mp4 \
  --browser-arg --no-sandbox --browser-arg --disable-dev-shm-usage
```

## Details

- Installs shot-scraper (with the `narrate` extra) **from the build context**, then the matching Playwright Chromium via `playwright install --with-deps chromium`, so the browser never drifts from shot-scraper's pinned Playwright.
- Bakes the Kokoro model + voices into `$XDG_CACHE_HOME/shot-scraper/kokoro`, so narration runs fully offline (no download at `docker run` time).
- `ENTRYPOINT ["shot-scraper"]`, `WORKDIR /work` — mount a directory as `/work` for inputs/outputs.
- Chromium can't sandbox as root in a container, so the docs and Dockerfile header show the required `--browser-arg --no-sandbox --browser-arg --disable-dev-shm-usage`. `--network host` (Linux) or `host.docker.internal` (Docker Desktop) reaches a server on the host.
- Adds a "Running with Docker" section to `docs/installation.md`.

## Testing

Built the image and verified inside the container:
- a screenshot of a local file renders to PNG;
- `shot-scraper video ... --mp4` records a video **and** synthesizes narration offline (baked Kokoro model + espeak-ng), producing an MP4 with a real AAC audio track (`ffprobe` confirms h264 video + aac audio).

## Depends on #200

The image installs `shot-scraper[narrate]`, so it builds on the narration work in #200 — this branch is stacked on it and the diff will settle to just the three Docker files once #200 merges. Happy to rebase onto `main` after that.


<!-- readthedocs-preview shot-scraper start -->
----
📚 Documentation preview 📚: https://shot-scraper--201.org.readthedocs.build/en/201/

<!-- readthedocs-preview shot-scraper end -->