### PR TITLE
Add expect / expect_gone storyboard assertion actions

### DIFF
--- a/docs/video.md
+++ b/docs/video.md
@@ -531,6 +531,33 @@ Wait for the current URL to match a string or glob pattern:
 - wait_for_url: "**/pricing"
 ```
 
+### expect
+
+Assert that a condition holds, **failing the recording** if it is never met. Unlike `wait_for`, which just waits, `expect` turns an unmet condition into a hard error — useful for proving that an action actually changed the page rather than silently recording a no-op.
+
+The target is a CSS `selector`, a `text` substring of the page, or both (when both are given the text is matched inside the selected element). A short string is treated as a selector:
+
+```yaml
+- expect: "#saved-indicator"
+- expect: { text: "Saved" }
+- expect: { selector: ".toast", text: "Saved" }
+```
+
+It polls until the condition holds or the timeout is reached (the command's `--timeout`, or a per-step `timeout` in milliseconds):
+
+```yaml
+- expect: { text: "Loaded", timeout: 5000 }
+```
+
+### expect_gone
+
+The inverse of `expect`: assert that the target is **absent**, failing the recording if it never disappears. This catches an action that should have removed or reverted something but didn't:
+
+```yaml
+- expect_gone: { text: "Draft saved" }
+- expect_gone: { selector: ".spinner" }
+```
+
 ### open
 
 Navigate during a scene. Relative URLs are resolved against the current page URL.

--- a/shot_scraper/cli.py
+++ b/shot_scraper/cli.py
@@ -18,6 +18,8 @@ from playwright.sync_api import sync_playwright, Error, TimeoutError
 
 from shot_scraper.video import (
     ClickAction,
+    ExpectAction,
+    ExpectGoneAction,
     FillAction,
     JavascriptAction,
     OpenAction,
@@ -1855,6 +1857,8 @@ def _run_storyboard_action(
         _storyboard_wait_for(page, action.selector)
     elif isinstance(action, WaitForUrlAction):
         page.wait_for_url(action.url)
+    elif isinstance(action, (ExpectAction, ExpectGoneAction)):
+        _storyboard_expect(page, action)
     elif isinstance(action, OpenAction):
         _storyboard_goto(page, action.url, skip=skip, fail=fail)
     elif isinstance(action, JavascriptAction):
@@ -1895,6 +1899,36 @@ def _storyboard_wait_for(page, selector):
     if not isinstance(selector, str):
         raise click.ClickException("wait_for: must be a selector string")
     page.locator(selector).wait_for()
+
+
+def _storyboard_expect(page, action):
+    """Assert a post-condition, failing the recording if it is never met.
+
+    `expect` waits for the target to be present; `expect_gone` waits for it to be
+    absent. The target is a CSS `selector`, a `text` substring of the page (or of
+    the selected element's text, if both are given), or both. Polls up to the
+    context timeout, or `timeout` milliseconds if the action sets one.
+    """
+    negate = isinstance(action, ExpectGoneAction)
+    present = (
+        "() => {"
+        f"const sel={json.dumps(action.selector)}, text={json.dumps(action.text)};"
+        "const scope = sel ? document.querySelector(sel) : document.body;"
+        "if (sel && !scope) return false;"
+        "if (text == null) return sel ? !!scope : true;"
+        "return (scope ? scope.innerText : '').includes(text);"
+        "}"
+    )
+    expression = f"() => !(({present})())" if negate else present
+    try:
+        page.wait_for_function(expression, timeout=action.timeout)
+    except TimeoutError:
+        label = "expect_gone" if negate else "expect"
+        raise click.ClickException(
+            f"{label} assertion failed (selector={action.selector!r}, "
+            f"text={action.text!r}): post-condition not met — the page never "
+            f"reached the {'absent' if negate else 'present'} state in time"
+        )
 
 
 def _storyboard_pause(seconds):

--- a/shot_scraper/video.py
+++ b/shot_scraper/video.py
@@ -105,6 +105,32 @@ class WaitForUrlAction(StoryboardBaseModel):
     url: str
 
 
+class ExpectAction(StoryboardBaseModel):
+    action: Literal["expect"]
+    selector: str | None = None
+    text: str | None = None
+    timeout: PositiveInt | None = None
+
+    @model_validator(mode="after")
+    def require_target(self):
+        if self.selector is None and self.text is None:
+            raise ValueError("expect: needs a selector: and/or text:")
+        return self
+
+
+class ExpectGoneAction(StoryboardBaseModel):
+    action: Literal["expect_gone"]
+    selector: str | None = None
+    text: str | None = None
+    timeout: PositiveInt | None = None
+
+    @model_validator(mode="after")
+    def require_target(self):
+        if self.selector is None and self.text is None:
+            raise ValueError("expect_gone: needs a selector: and/or text:")
+        return self
+
+
 class OpenAction(StoryboardBaseModel):
     action: Literal["open"]
     url: str
@@ -142,6 +168,8 @@ StoryboardAction = Annotated[
         PauseAction,
         WaitForAction,
         WaitForUrlAction,
+        ExpectAction,
+        ExpectGoneAction,
         OpenAction,
         JavascriptAction,
         ScreenshotAction,
@@ -160,6 +188,8 @@ STORYBOARD_ACTIONS = {
     "pause",
     "wait_for",
     "wait_for_url",
+    "expect",
+    "expect_gone",
     "open",
     "javascript",
     "js",
@@ -279,6 +309,17 @@ def _normalize_storyboard_action(action):
 
     if action_name == "wait_for_url":
         return {"action": "wait_for_url", "url": value}
+
+    if action_name in ("expect", "expect_gone"):
+        if isinstance(value, str):
+            return {"action": action_name, "selector": value}
+        if isinstance(value, dict):
+            value = dict(value)
+            # `contains:` reads naturally as an alias for the text substring
+            if "contains" in value and "text" not in value:
+                value["text"] = value.pop("contains")
+            return {"action": action_name, **value}
+        raise ValueError(f"{action_name}: must be a selector string or mapping")
 
     if action_name == "open":
         return {"action": "open", "url": value}

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1,9 +1,13 @@
 from io import StringIO
 
 import pytest
+from click.testing import CliRunner
 
+from shot_scraper.cli import cli
 from shot_scraper.video import (
     ClickAction,
+    ExpectAction,
+    ExpectGoneAction,
     FillAction,
     OpenAction,
     PressAction,
@@ -204,6 +208,16 @@ scenes:
 """,
             "scenes.0.banana: Extra inputs are not permitted",
         ),
+        (
+            """
+output: demo.webm
+url: https://example.com/
+scenes:
+- do:
+  - expect: {}
+""",
+            "scenes.0.do.0.expect: expect: needs a selector: and/or text:",
+        ),
     ),
 )
 def test_load_storyboard_validation_errors(yaml, expected):
@@ -211,3 +225,87 @@ def test_load_storyboard_validation_errors(yaml, expected):
         parse_storyboard(yaml)
 
     assert str(ex.value) == expected
+
+
+def test_load_storyboard_normalizes_expect_actions():
+    storyboard = parse_storyboard(
+        """
+output: demo.webm
+url: https://example.com/
+scenes:
+- do:
+  - expect: "#done"
+  - expect: { text: "Saved", timeout: 500 }
+  - expect_gone: { contains: "Loading" }
+"""
+    )
+    actions = storyboard.scenes[0].do
+    assert isinstance(actions[0], ExpectAction)
+    assert actions[0].selector == "#done" and actions[0].text is None
+    assert isinstance(actions[1], ExpectAction)
+    assert actions[1].text == "Saved" and actions[1].timeout == 500
+    # `contains:` is an alias for `text:`
+    assert isinstance(actions[2], ExpectGoneAction)
+    assert actions[2].text == "Loading"
+
+
+EXPECT_HTML = "<!DOCTYPE html><html><head><title>t</title></head><body><h1 id='h'>Present text</h1></body></html>"
+
+
+def _record(runner, storyboard):
+    open("index.html", "w").write(EXPECT_HTML)
+    open("sb.yml", "w").write(storyboard)
+    return runner.invoke(cli, ["video", "sb.yml", "--browser-arg", "--no-sandbox"])
+
+
+def test_expect_passes_when_condition_holds():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = _record(
+            runner,
+            """
+output: demo.webm
+url: index.html
+scenes:
+- do:
+  - expect: "#h"
+  - expect: { text: "Present text" }
+  - expect_gone: { text: "never here" }
+  - pause: 0.2
+""",
+        )
+        assert result.exit_code == 0, result.output
+
+
+def test_expect_fails_recording_when_condition_never_holds():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = _record(
+            runner,
+            """
+output: demo.webm
+url: index.html
+scenes:
+- do:
+  - expect: { text: "this is absent", timeout: 800 }
+""",
+        )
+        assert result.exit_code != 0
+        assert "expect assertion failed" in result.output
+
+
+def test_expect_gone_fails_when_target_stays_present():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = _record(
+            runner,
+            """
+output: demo.webm
+url: index.html
+scenes:
+- do:
+  - expect_gone: { selector: "#h", timeout: 800 }
+""",
+        )
+        assert result.exit_code != 0
+        assert "expect_gone assertion failed" in result.output


### PR DESCRIPTION
## What

Adds two storyboard actions to `shot-scraper video`: **`expect`** and **`expect_gone`**. They assert a post-condition and **fail the recording** if it is never met.

```yaml
scenes:
- name: Save
  do:
    - click: "#save"
    - expect: { text: "Saved" }        # fails the recording if "Saved" never appears
    - click: "#undo"
    - expect_gone: { text: "Saved" }   # fails if it never disappears
```

## Why

Storyboards already have `wait_for`, but a wait that times out and a wait that succeeds can look the same in the resulting video, and a scene can record an action that silently did nothing. `expect`/`expect_gone` make the intent an assertion: if the page doesn't reach the expected state, shot-scraper exits with a clear error instead of producing a clean-looking video of a no-op. This is handy for demos and for CI recordings that should fail when the app misbehaves.

## Details

- The target is a CSS `selector`, a `text` substring of the page, or both (with both, the text is matched inside the selected element). A bare string is treated as a selector; `contains:` is accepted as an alias for `text:`.
- Polls via Playwright's `wait_for_function` up to the command's `--timeout`, or a per-step `timeout` in milliseconds.
- On timeout it raises a `ClickException` naming the selector/text and whether it was waiting for the present or absent state.
- New `ExpectAction` / `ExpectGoneAction` models (validated to require at least one of `selector`/`text`), wired into `_run_storyboard_action` via a small `_storyboard_expect` helper.

## Tests & docs

- `test_video.py`: normalization/parsing (string→selector, mapping, `contains` alias, the require-a-target validation error) plus three real recordings — assertions that hold let the recording finish, and both a false `expect` and an `expect_gone` on a still-present element fail it with the expected message.
- Added `expect` / `expect_gone` sections to the storyboard actions reference in `docs/video.md`.

Branches cleanly from `main`; independent of my other open PRs.


<!-- readthedocs-preview shot-scraper start -->
----
📚 Documentation preview 📚: https://shot-scraper--202.org.readthedocs.build/en/202/

<!-- readthedocs-preview shot-scraper end -->