### PR TITLE
Add --gif option to the video command

### DIFF
--- a/docs/video.md
+++ b/docs/video.md
@@ -67,6 +67,14 @@ shot-scraper video storyboard.yml --mp4
 
 If `ffmpeg` is not installed, the WebM file is still created but the command exits with a non-zero status and an error explaining that the MP4 was not created.
 
+Use `--gif` to instead convert the recorded WebM video to an animated GIF using `ffmpeg`, again reusing the output filename with the extension replaced by `.gif`:
+
+```bash
+shot-scraper video storyboard.yml --gif
+```
+
+GIFs are much larger than the equivalent MP4, so they suit short clips; the same `ffmpeg` requirement and error handling apply.
+
 ## Storyboard structure
 
 A storyboard file is a YAML mapping with these keys:
@@ -742,9 +750,9 @@ Usage: shot-scraper video [OPTIONS] STORYBOARD_FILE
 
   Top-level YAML keys:
 
-      output: WebM filename. -o/--output overrides this. With --mp4, an MP4
-        is also written using the same filename with the suffix replaced by
-        .mp4.
+      output: WebM filename. -o/--output overrides this. With --mp4 or --gif,
+        an MP4 or GIF is also written using the same filename with the suffix
+        replaced by .mp4 or .gif.
       url: Starting URL, bare domain, or local HTML path. Omit this only if
         the first scene has open:.
       sh: Shell command string or argument list to run before python: and
@@ -812,6 +820,8 @@ Options:
   --auth-username TEXT            Username for HTTP Basic authentication
   --leave-server                  Leave servers running when script finishes
   --mp4                           Also convert the recorded WebM video to MP4
+                                  using ffmpeg
+  --gif                           Also convert the recorded WebM video to GIF
                                   using ffmpeg
   --help                          Show this message and exit.
 ```

--- a/shot_scraper/cli.py
+++ b/shot_scraper/cli.py
@@ -516,6 +516,11 @@ def _browser_context(
     is_flag=True,
     help="Also convert the recorded WebM video to MP4 using ffmpeg",
 )
+@click.option(
+    "--gif",
+    is_flag=True,
+    help="Also convert the recorded WebM video to GIF using ffmpeg",
+)
 def video(
     storyboard_file,
     output,
@@ -534,6 +539,7 @@ def video(
     auth_password,
     leave_server,
     mp4,
+    gif,
 ):
     """
     Record a WebM video from a YAML storyboard.
@@ -584,9 +590,9 @@ def video(
     Top-level YAML keys:
 
     \b
-        output: WebM filename. -o/--output overrides this. With --mp4, an MP4
-          is also written using the same filename with the suffix replaced by
-          .mp4.
+        output: WebM filename. -o/--output overrides this. With --mp4 or --gif,
+          an MP4 or GIF is also written using the same filename with the suffix
+          replaced by .mp4 or .gif.
         url: Starting URL, bare domain, or local HTML path. Omit this only if
           the first scene has open:.
         sh: Shell command string or argument list to run before python: and
@@ -663,6 +669,8 @@ def video(
         )
         if mp4:
             _convert_video_to_mp4(storyboard_config.output, silent=silent)
+        if gif:
+            _convert_video_to_gif(storyboard_config.output, silent=silent)
     except TimeoutError as e:
         raise click.ClickException(str(e))
 
@@ -699,6 +707,38 @@ def _convert_video_to_mp4(output, silent=False):
     if not silent:
         click.echo(f"MP4 written to '{mp4_output}'", err=True)
     return mp4_output
+
+
+def _convert_video_to_gif(output, silent=False):
+    gif_output = str(pathlib.Path(output).with_suffix(".gif"))
+    args = [
+        "ffmpeg",
+        "-y",
+        "-i",
+        output,
+        "-filter_complex",
+        "fps=10,scale=800:-1:flags=lanczos,split[a][b];[a]palettegen[p];[b][p]paletteuse",
+        "-loop",
+        "0",
+        gif_output,
+    ]
+    try:
+        subprocess.run(args, check=True, capture_output=True, text=True)
+    except FileNotFoundError:
+        raise click.ClickException(
+            "WebM was created, but GIF conversion failed: ffmpeg is not installed "
+            "or not on PATH"
+        )
+    except subprocess.CalledProcessError as ex:
+        reason = (ex.stderr or ex.stdout or "").strip()
+        if not reason:
+            reason = f"ffmpeg exited with status {ex.returncode}"
+        raise click.ClickException(
+            f"WebM was created, but GIF conversion failed: {reason}"
+        )
+    if not silent:
+        click.echo(f"GIF written to '{gif_output}'", err=True)
+    return gif_output
 
 
 @cli.command()

--- a/tests/test_shot_scraper.py
+++ b/tests/test_shot_scraper.py
@@ -331,6 +331,7 @@ def test_video_help_documents_storyboard_format():
         '      - type: {into: "selector", text: "value", delay_ms: 25}' in result.output
     )
     assert "  --mp4" in result.output
+    assert "  --gif" in result.output
     assert "\b" not in result.output
 
 
@@ -511,6 +512,99 @@ scenes:
         assert not pathlib.Path("demo.mp4").exists()
         assert (
             "Error: WebM was created, but MP4 conversion failed: ffmpeg is not "
+            "installed or not on PATH\n"
+        ) in result.output
+
+
+@pytest.mark.parametrize(
+    ("output_filename", "gif_filename"),
+    (
+        ("demo.webm", "demo.gif"),
+        ("recording.video", "recording.gif"),
+        ("demo", "demo.gif"),
+    ),
+)
+def test_video_gif_converts_webm_after_recording(mocker, output_filename, gif_filename):
+    runner = CliRunner()
+    events = []
+
+    def record_storyboard(storyboard_config, **kwargs):
+        events.append(("record", storyboard_config.output))
+        pathlib.Path(storyboard_config.output).write_bytes(b"webm")
+
+    def run_ffmpeg(args, **kwargs):
+        events.append(("ffmpeg", args, kwargs))
+        assert pathlib.Path(args[3]).exists()
+        pathlib.Path(args[-1]).write_bytes(b"gif")
+        return cli_module.subprocess.CompletedProcess(args, 0)
+
+    mocker.patch.object(cli_module, "_record_storyboard", side_effect=record_storyboard)
+    mocker.patch.object(cli_module.subprocess, "run", side_effect=run_ffmpeg)
+
+    with runner.isolated_filesystem():
+        pathlib.Path("storyboard.yml").write_text("""
+output: {output_filename}
+url: https://example.com/
+scenes:
+- name: One
+  do:
+  - pause: 0.1
+""".format(output_filename=output_filename).strip())
+        result = runner.invoke(cli, ["video", "storyboard.yml", "--gif"])
+
+        assert result.exit_code == 0, result.output
+        assert pathlib.Path(output_filename).read_bytes() == b"webm"
+        assert pathlib.Path(gif_filename).read_bytes() == b"gif"
+        assert events == [
+            ("record", output_filename),
+            (
+                "ffmpeg",
+                [
+                    "ffmpeg",
+                    "-y",
+                    "-i",
+                    output_filename,
+                    "-filter_complex",
+                    "fps=10,scale=800:-1:flags=lanczos,split[a][b];[a]palettegen[p];[b][p]paletteuse",
+                    "-loop",
+                    "0",
+                    gif_filename,
+                ],
+                {"check": True, "capture_output": True, "text": True},
+            ),
+        ]
+        assert f"GIF written to '{gif_filename}'" in result.output
+
+
+def test_video_gif_missing_ffmpeg_leaves_webm(mocker):
+    runner = CliRunner()
+
+    def record_storyboard(storyboard_config, **kwargs):
+        pathlib.Path(storyboard_config.output).write_bytes(b"webm")
+
+    mocker.patch.object(cli_module, "_record_storyboard", side_effect=record_storyboard)
+    mocker.patch.object(
+        cli_module.subprocess,
+        "run",
+        side_effect=FileNotFoundError("ffmpeg"),
+    )
+
+    with runner.isolated_filesystem():
+        pathlib.Path("storyboard.yml").write_text("""
+output: demo.webm
+url: https://example.com/
+scenes:
+- name: One
+  do:
+  - pause: 0.1
+""".strip())
+        result = runner.invoke(cli, ["video", "storyboard.yml", "--gif"])
+
+        assert result.exit_code == 1
+        assert pathlib.Path("demo.webm").read_bytes() == b"webm"
+        assert not pathlib.Path("demo.gif").exists()
+        assert (
+            "Error: WebM was created, but GIF conversion failed: ffmpeg is not "
             "installed or not on PATH\n"
         ) in result.output
 


### PR DESCRIPTION
Adds `--gif` to `shot-scraper video`, alongside the existing `--mp4`, to convert the recorded WebM to an animated GIF with `ffmpeg`:

```bash
shot-scraper video storyboard.yml --gif
```

It mirrors `--mp4` exactly: the WebM is written first, the GIF reuses the output filename with the suffix replaced by `.gif`, and a missing/failing `ffmpeg` raises the same `ClickException` (leaving the WebM in place). The conversion uses a `fps=10,scale=800` palettegen `-filter_complex`.

Includes docs (video.md prose + regenerated `--help` cog block) and tests mirroring the `--mp4` conversion + missing-ffmpeg pair. Full suite passes locally and a real `--gif` run produces a valid GIF.


<!-- readthedocs-preview shot-scraper start -->
----
📚 Documentation preview 📚: https://shot-scraper--203.org.readthedocs.build/en/203/

<!-- readthedocs-preview shot-scraper end -->